### PR TITLE
agent: name this turn's uploads by what the request called them

### DIFF
--- a/mirobody/agent/deep/files_backend.py
+++ b/mirobody/agent/deep/files_backend.py
@@ -66,6 +66,7 @@ class ThFilesBackend(PgFilesystemBackend):
         scope: str,                     # "uploads" | "library"
         file_keys: list[str] | None = None,
         supports_file_block: bool = False,
+        turn_names: dict[str, str] | None = None,
     ):
         if scope not in ("uploads", "library"):
             raise ValueError(f"ThFilesBackend scope must be uploads|library, got {scope!r}")
@@ -74,6 +75,16 @@ class ThFilesBackend(PgFilesystemBackend):
         super().__init__(user_id=user_id, session_id="", scope=scope,
                          supports_file_block=supports_file_block)
         self._keys = [str(k) for k in (file_keys or [])][:_MAX_SESSION_FILES]
+        # file_key -> the name THIS request attached the file under. `/uploads/`
+        # names a file by this rather than by `th_files.file_name`, which is not
+        # stable: the upload pass asks an LLM for a descriptive name and
+        # overwrites the column with it (`handlers/base.py::_extract_abstract`),
+        # and that write lands DURING the turn, concurrently with the agent. The
+        # column is the right name for `/library/`, where it is discovered by
+        # `ls`; it is the wrong one here, because `_attachment_reminder` has
+        # already told the model the request's name and a rename mid-turn turned
+        # that path into `file_not_found` (`ls` had listed it seconds earlier).
+        self._turn_names = {str(k): str(v) for k, v in (turn_names or {}).items() if v}
 
     # ── the projection ───────────────────────────────────────────────────────
 
@@ -148,7 +159,11 @@ class ThFilesBackend(PgFilesystemBackend):
         seen: set[str] = set()
         out: list[dict[str, Any]] = []
         for r in rows or []:
-            base = safe_basename(r.get("file_name") or r.get("file_key") or "")
+            # `/uploads/` names this turn's attachments by the name the request
+            # carried; only `/library/` reads the (rewritable) stored name. See
+            # `_turn_names` in __init__ for why the column cannot be trusted here.
+            pinned = self._turn_names.get(str(r.get("file_key") or ""))
+            base = safe_basename(pinned or r.get("file_name") or r.get("file_key") or "")
             if not base:
                 continue
             # Newest wins; a repeat name gets its key appended rather than

--- a/mirobody/agent/deep/files_backend.py
+++ b/mirobody/agent/deep/files_backend.py
@@ -170,7 +170,8 @@ class ThFilesBackend(PgFilesystemBackend):
             # shadowing the older file, matching what the sync did.
             if base in seen:
                 key = str(r.get("file_key") or "")
-                base = f"{base}__thf_{key[:8]}" if key else base
+                suffix = safe_basename(key)[:8]
+                base = f"{base}__thf_{suffix}" if suffix else base
                 if base in seen:
                     continue
             seen.add(base)

--- a/mirobody/agent/deep_agent.py
+++ b/mirobody/agent/deep_agent.py
@@ -412,8 +412,10 @@ class DeepAgent():
         # The names `_attachment_reminder` announces to the model, so the mount
         # answers to exactly the paths the model was handed. Deriving them from
         # `th_files.file_name` instead would reintroduce the mid-turn rename race
-        # (see `ThFilesBackend.__init__`).
-        this_turn_names = {str(f["file_key"]): str(f.get("file_name") or "")
+        # (see `ThFilesBackend.__init__`). The `file_key` fallback mirrors the
+        # reminder's (`_attachment_reminder`, below) — a request that carries no
+        # `file_name` must still name the file the same way at both ends.
+        this_turn_names = {str(f["file_key"]): str(f.get("file_name") or f.get("file_key") or "")
                            for f in (file_list or [])
                            if isinstance(f, dict) and f.get("file_key")}
 

--- a/mirobody/agent/deep_agent.py
+++ b/mirobody/agent/deep_agent.py
@@ -409,9 +409,18 @@ class DeepAgent():
         this_turn_keys = [str(f["file_key"]) for f in (file_list or [])
                           if isinstance(f, dict) and f.get("file_key")]
 
+        # The names `_attachment_reminder` announces to the model, so the mount
+        # answers to exactly the paths the model was handed. Deriving them from
+        # `th_files.file_name` instead would reintroduce the mid-turn rename race
+        # (see `ThFilesBackend.__init__`).
+        this_turn_names = {str(f["file_key"]): str(f.get("file_name") or "")
+                           for f in (file_list or [])
+                           if isinstance(f, dict) and f.get("file_key")}
+
         memory = ProfileBackend(user_id=user_id)
         uploads = ThFilesBackend(user_id=user_id, scope="uploads",
                                  file_keys=this_turn_keys,
+                                 turn_names=this_turn_names,
                                  supports_file_block=supports_file_block)
         library = ThFilesBackend(user_id=user_id, scope="library",
                                  file_keys=this_turn_keys,


### PR DESCRIPTION
Fixes #40. Independent of #41 — different files, no conflict.

## The bug

`ls /uploads` listed an attachment that `read_file` then could not open, and
`glob` for that name found nothing — all inside one turn, seconds apart. The
agent told the user their successfully uploaded report was unreadable and asked
them to send it again.

## Root cause

The two ends addressed the file by different names.

* `_attachment_reminder` (`deep_agent.py`) tells the model to read
  `/uploads/<name>` using the name from the **request payload** — the client's
  filename.
* `ThFilesBackend._files` derived the mount's paths from **`th_files.file_name`**.

Those are not the same string. `handlers/base.py::_extract_abstract` asks an LLM
for a descriptive name during upload processing and **overwrites the column with
it** — `labreport3.png` becomes `2026-08-22_Lab_Report_Patient_Demo1.png`.

Extraction runs concurrently with the agent, so that write lands *during* the
turn, which is what made it look intermittent:

```
ls        -> before the rename -> ['/uploads/labreport3.png']   ok
          -- rename commits --
read_file -> after  the rename -> file_not_found
glob      -> after  the rename -> No files found
```

`glob` agreeing with `read_file` was the tell: by then the file really did have
another name. No query ever failed — the row came back every time, under a name
that had moved.

## The change

`/uploads/` names this turn's attachments by what the request attached them
under. The mount and the reminder now come from one source, so no rename can
move a path out from under the model mid-turn.

`/library/` is unchanged and still shows the stored, LLM-generated name: it is
discovered with `ls`, nothing announces it in advance, and there the descriptive
name is the useful one.

## Verification

![before and after](https://raw.githubusercontent.com/abietic/mirobody/evidence/attachment-only-turn/.evidence/fix40.png)

Deterministically, for a file whose rename had already landed — before, the
mount served `/2026-08-22_Lab_Report_Patient_Demo1.png` while the model was told
`/uploads/labreport3.png` and `_fetch_row` missed; after, both are
`/uploads/labreport3.png` and it hits. `/library/` still lists the descriptive
names.

End to end on a fresh upload, with the rename committing **827 ms before** the
read — the exact timing that used to fail:

```
01:56:16,793  Updating th_files with 1 processed files       <- rename lands
01:56:17,620  [Tool Call] read_file '/uploads/labreport4.png'
              -> [{'type': 'image', 'base64': 'iVBORw0KGgo...'}]
```

The agent read the report correctly (HbA1c 6.1 %, triglycerides 3.4 mmol/L, both
matching the image) while `th_files.file_name` was already
`2026-08-23_Lab_Report_Patient_Demo1.png`.

Gates from CONTRIBUTING.md, on this branch:

```
python -m pytest -q     ->  197 passed in 10.96s
lint-imports            ->  Contracts: 2 kept, 0 broken.
```

## One thing left for a maintainer

The LLM rename itself is untouched — it is a feature, and the descriptive name is
what the file library should show. But a file attached to the current turn is now
reachable only under the request's name, while the UI shows it under the
generated one. If a user refers to the name they see on screen, the agent will
not find it by that name until the file has aged into `/library/`. Making the
mount answer to both names is a small change; I did not make it because it is a
product call about which name is canonical.
