### PR TITLE
agent: build the attachment note from the mount, not from the request (1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Changelog
 
-## 1.2.1 — unreleased
+## 1.2.2 — unreleased
+
+### Fixed
+
+- **An attachment-only chat turn is a question.** Attaching a file and pressing
+  send without typing anything was refused with `-3 Empty question.` before the
+  agent was ever reached — `chat_handler` judged emptiness on the message text
+  alone. It now judges the whole turn, and a turn that carries files but no
+  words is normalised once, at the top of `handle_request`, into a stand-in
+  question in the request's language (`mirobody/utils/locales/chat.json`). One
+  field, so persistence, the session title, the resume hint, the `question`
+  kwarg and the message the model receives all agree; no turn reaches a
+  provider as a zero-length user message, which Anthropic rejects outright and
+  LangGraph would checkpoint into the session and replay. (#39, #41)
+
+- **`/uploads/` paths no longer move under the model mid-turn.** The upload
+  pass asks an LLM for a descriptive filename and overwrites
+  `th_files.file_name` with it, concurrently with the agent — so `ls` listed a
+  file that `read_file` then could not open, and the agent told the user their
+  report was unreadable. `/uploads/` now names this turn's attachments by what
+  the request attached them under, and the note that announces those paths to
+  the model is built from the mount itself rather than from the request, so it
+  cannot name a path the mount does not serve: same-named attachments are
+  announced apart, a `file_key` whose row is deleted or is not the caller's is
+  not announced at all, and a listing shortened by the per-turn file cap says
+  so. `/library/` still shows the stored, descriptive name. (#40, #42)
+
+## 1.2.1 — released 2026-08-23
 
 The first release in which `pip install mirobody` actually works, and the MCP
 surface is on the current protocol. There are **breaking changes to the MCP tool

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,12 +42,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **1.2.1 が PyPI に出るまでは、ソースチェックアウトから実行してほしい**
-> （`git clone` + `git lfs pull` + `pip install -e .`。後述の「一式を動かす」参照）。
-> 公開中の `1.0.62` wheel は空箱だ ―― CLI が無く、リゾルバのデータファイルは
-> 133バイトの Git-LFS ポインタスタブなので、何も解決できない。詳細は
-> [CHANGELOG](CHANGELOG.md)。
-
 <p align="center">
   <img src="docs/images/resolve-demo.ja.gif"
        alt="mirobody resolve：4つの言語が1つのLOINCコードに落ちる、完全オフライン" width="880">

--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **Until 1.2.1 reaches PyPI, run this from a source checkout** (`git clone` +
-> `git lfs pull` + `pip install -e .`, as in [Run the whole thing](#-run-the-whole-thing)):
-> the published `1.0.62` wheel is an empty shell — no CLI, and the resolver data
-> files are 133-byte Git-LFS pointer stubs, so nothing resolves. Details in the
-> [CHANGELOG](CHANGELOG.md).
-
 <p align="center">
   <img src="docs/images/resolve-demo.gif"
        alt="mirobody resolve: four languages landing on one LOINC code, fully offline" width="880">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,11 +42,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **在 1.2.1 发布到 PyPI 之前，请从源码 checkout 运行**（`git clone` +
-> `git lfs pull` + `pip install -e .`，见下文「把整套跑起来」）：当前发布的
-> `1.0.62` wheel 是个空壳——没有 CLI，解析器数据文件只是 133 字节的 Git-LFS
-> 指针 stub，什么都解析不了。详见 [CHANGELOG](CHANGELOG.md)。
-
 <p align="center">
   <img src="docs/images/resolve-demo.zh-CN.gif"
        alt="mirobody resolve：四种语言落到同一个 LOINC 码，完全离线" width="880">

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -42,11 +42,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **在 1.2.1 發佈到 PyPI 之前，請從原始碼 checkout 執行**（`git clone` +
-> `git lfs pull` + `pip install -e .`，見下文「把整套跑起來」）：目前發佈的
-> `1.0.62` wheel 是個空殼——沒有 CLI，解析器資料檔只是 133 位元組的 Git-LFS
-> pointer stub，什麼都解析不了。詳見 [CHANGELOG](CHANGELOG.md)。
-
 <p align="center">
   <img src="docs/images/resolve-demo.zh-TW.gif"
        alt="mirobody resolve：四種語言落到同一個 LOINC 碼，完全離線" width="880">

--- a/mirobody/__init__.py
+++ b/mirobody/__init__.py
@@ -19,4 +19,4 @@ try:
     __version__ = _version("mirobody")
 except Exception:
     import os
-    __version__ = os.environ.get("MIROBODY_VERSION") or "1.2.1"
+    __version__ = os.environ.get("MIROBODY_VERSION") or "1.2.2"

--- a/mirobody/agent/deep_agent.py
+++ b/mirobody/agent/deep_agent.py
@@ -866,18 +866,9 @@ class DeepAgent():
             # duplicate that and blow up the context. BaseAgent still uses
             # files_data (it has no virtual FS).
 
-            # Tell the model exactly which files were attached this turn (and
-            # their /uploads/ paths) so it reads them without an ls round-trip and
-            # never misses one. Transient — appended to the run's messages only,
-            # not the cached system prompt. Matches the incoming list's element
-            # type (BaseMessage vs dict) to avoid mixing forms.
-            reminder = _attachment_reminder(file_list)
-            if reminder:
-                if messages and isinstance(messages[-1], BaseMessage):
-                    from langchain_core.messages import HumanMessage
-                    messages = [*messages, HumanMessage(content=reminder)]
-                else:
-                    messages = [*messages, {"role": "user", "content": reminder}]
+            # The attachment reminder is built AFTER the mount exists — see the
+            # append below, and `_attachment_reminder` for why the paths have to
+            # come from the mount rather than from this request.
 
             llm_client, model_name, fallback_msg, loaded_tools, system_prompt = await self._prepare_context(
                 user_id=user_id,
@@ -903,6 +894,19 @@ class DeepAgent():
                 file_list=file_list,
                 supports_file_block=supports_file_block,
             )
+
+            # Tell the model exactly which files this turn attached and where to
+            # read them, so it never needs an `ls /uploads/` round-trip and never
+            # silently misses one. Transient — appended to the run's messages
+            # only, not the cached system prompt. Matches the list's element type
+            # (BaseMessage vs dict) to avoid mixing forms.
+            reminder = await _attachment_reminder(backend, file_list)
+            if reminder:
+                if final_messages and isinstance(final_messages[-1], BaseMessage):
+                    from langchain_core.messages import HumanMessage
+                    final_messages = [*final_messages, HumanMessage(content=reminder)]
+                else:
+                    final_messages = [*final_messages, {"role": "user", "content": reminder}]
 
             token_counter = TokenUsageCallback()
             stream_config = self._create_stream_config(user_id, token_counter, session_id)
@@ -1088,30 +1092,76 @@ class DeepAgent():
         return llm_clients
 
 
-def _attachment_reminder(file_list: list[dict[str, Any]] | None) -> str | None:
-    """A short note naming the files attached to THIS turn and their /uploads/
-    paths, so the model reads them without first having to ``ls /uploads/`` (and
-    never silently misses an attachment). Returns None when nothing is attached.
+async def _attachment_reminder(backend: Any,
+                               file_list: list[dict[str, Any]] | None) -> str | None:
+    """A short note naming this turn's attachments and their `/uploads/` paths,
+    so the model reads them without first having to ``ls /uploads/`` (and never
+    silently misses one). Returns None when nothing readable is attached.
+
+    **The paths come from the MOUNT, never from the request.** Deriving them
+    from the request payload is what issue #40 was: two independent name
+    computations that agreed only for as long as nothing renamed the file
+    mid-turn. Pinning `/uploads/` to the request's names (PR #42) made them
+    agree in the common case, but a request-derived listing can still name a
+    path the mount does not serve, in at least three ways:
+
+    * two attachments share a name — the mount serves the second under a
+      ``__thf_`` suffix the request cannot predict, so a request-derived note
+      announces one path twice and every read lands on the first file;
+    * the row is gone or was never the caller's (deleted, another user's
+      `file_key`) — the projection filters on `user_id` and `is_del`, the
+      request does not, so the note promises a file the mount will refuse;
+    * more than `_MAX_SESSION_FILES` attachments — the mount truncates, and a
+      request-derived note lists files that are not there.
+
+    Every one of those ends the same way for the user: the agent says the
+    upload is unreadable and asks them to send it again. Asking the projection
+    removes the class rather than the instances, and keeps this note correct
+    through any future change to how the mount names a file.
+
+    The listing is a snapshot taken as the turn starts, while the mount
+    re-queries on every tool call. That is the right way round: an upload
+    INSERTs its `th_files` row before the chat request carries its `file_key`,
+    so what lands mid-turn is an UPDATE (the rename), and anything the snapshot
+    somehow missed is still reachable with `ls`.
 
     Injected as a transient message (NOT the system prompt — that is cached and
     must stay stable across turns). Ephemeral: persistence saves the user
     question + assistant reply separately, not this note.
     """
-    items = [f for f in (file_list or []) if isinstance(f, dict) and f.get("file_key")]
-    paths: list[str] = []
-    from .deep.files_backend import _MAX_SESSION_FILES, safe_basename
+    attached = [f for f in (file_list or []) if isinstance(f, dict) and f.get("file_key")]
+    if not attached:
+        return None
 
-    for f in items[:_MAX_SESSION_FILES]:
-        name = safe_basename(f.get("file_name") or str(f.get("file_key")))
-        if name:
-            paths.append(f"/uploads/{name}")
+    # Anonymous sessions get a bare StateBackend with no /uploads/ route, and
+    # nothing to announce; `routes` is what tells the two apart.
+    uploads = getattr(backend, "routes", {}).get("/uploads/")
+    if uploads is None:
+        return None
+
+    # The public listing seam, so this note says exactly what the model's own
+    # `ls /uploads/` would say. A query failure returns no entries (`_files`
+    # logs and degrades); the model then falls back to `ls`, as it did before
+    # this note existed.
+    listed = await uploads.als("/")
+    paths = [f"/uploads{e['path']}" for e in (listed.entries or [])
+             if e.get("path") and not e.get("is_dir")]
     if not paths:
         return None
+
     listing = "\n".join(f"- {p}" for p in paths)
-    return (
-        "[System note: the user attached the following file(s) to THIS message. "
+    note = (
+        "[System note: the user attached file(s) to THIS message. "
         "Read the relevant one(s) with read_file before answering:\n"
-        f"{listing}]"
+        f"{listing}"
     )
+    # Say so rather than quietly listing fewer than were sent: a model that
+    # believes it has seen everything answers about everything.
+    if len(paths) < len(attached):
+        note += (
+            f"\n({len(paths)} of {len(attached)} attached file(s) are readable; "
+            "the rest are not in the user's file store.)"
+        )
+    return note + "]"
 
 

--- a/mirobody/test_readme_numbers.py
+++ b/mirobody/test_readme_numbers.py
@@ -153,13 +153,17 @@ _EMAIL = re.compile(r"[\w.+-]+@mirobody\.ai")
 _VERSION_SENTINEL = re.compile(r'or "(\d+\.\d+\.\d+)"')
 
 
-def test_the_awaited_version_is_the_source_tree_version():
-    """The READMEs tell readers to run from source "until X reaches PyPI",
-    the CHANGELOG's top entry names the release being prepared, and
-    `mirobody/__init__.py` carries the version the tree calls itself. All
-    three must agree, or a reader waits for a release that will never bear
-    that number. (When the release lands and the READMEs drop the warning,
-    delete the README half of this test; the CHANGELOG half stays.)"""
+def test_the_changelog_names_the_version_the_tree_calls_itself():
+    """The CHANGELOG's top entry names the release being prepared and
+    `mirobody/__init__.py` carries the version the tree calls itself; they
+    must agree, or the release notes describe a number nothing will ship
+    under.
+
+    This used to check a third place: the READMEs told readers to run from a
+    source checkout "until 1.2.1 reaches PyPI", because the published 1.0.62
+    wheel was an empty shell. 1.2.1 published on 2026-08-23, the four READMEs
+    dropped the warning, and this half went with it — as the previous version
+    of this docstring said it should."""
     src = (_ROOT / "mirobody" / "__init__.py").read_text(encoding="utf-8")
     version = _VERSION_SENTINEL.search(src).group(1)
 
@@ -168,14 +172,6 @@ def test_the_awaited_version_is_the_source_tree_version():
     assert top == version, (
         f"CHANGELOG's top entry is {top}; mirobody/__init__.py says {version}"
     )
-
-    for name in _READMES:
-        m = re.search(r"(\d+\.\d+\.\d+)(?= reaches| 发布| 發佈| が PyPI)", _text(name))
-        assert m, f"{name}: the run-from-source warning names no awaited version"
-        assert m.group(1) == version, (
-            f"{name} tells readers to wait for {m.group(1)}; "
-            f"the source tree is {version}"
-        )
 
 
 @pytest.mark.parametrize("name", _READMES)


### PR DESCRIPTION
The follow-up promised while reviewing #42, plus the 1.2.2 version bump.

## Why

`_attachment_reminder` derived `/uploads/` paths from the **request payload**;
the mount derives them from `th_files`. That is #40 in one line — two
independent name computations, agreeing only for as long as nothing renamed
the file mid-turn. #42 pinned the mount to the request's names, which made
them agree in the common case and left the class open: a request-derived
listing can still name a path the mount does not serve.

Three ways it does, all reproduced on `main` at `559c6dc` (`execute_query`
stubbed, both ends running the real code):

```
### A. the attachment's row is not in th_files (deleted / not this user's)
  the note tells the model : ['/uploads/report.png']
  the mount actually serves: []
    read_file /uploads/report.png -> file_not_found

### B. three attachments in one turn, all called photo.png
  the note tells the model : ['/uploads/photo.png', '/uploads/photo.png', '/uploads/photo.png']
  the mount actually serves: ['/uploads/photo.png', '/uploads/photo.png__thf_bbbb1111', '/uploads/photo.png__thf_cccc1111']
    all three reads -> the SAME file
```

**A** is the #40 symptom reached through a different door: the projection
filters on `user_id` and `is_del`, the request does not, so the note promises
a file `read_file` then refuses and the agent tells the user their upload is
unreadable. **B** is worse because nothing errors — the model is told it has
three files, reads one three times, and answers about all three. A third case,
more than `_MAX_SESSION_FILES` attachments, listed files the truncated mount
does not carry.

## What changed

The note is built **after** the mount exists, from `uploads.als("/")` — the
same public listing the model's own `ls` goes through — so it cannot name a
path the mount will not serve. It also says when it is listing fewer files
than were attached, instead of letting a model that has seen one of three
answer about three. `/library/` is untouched.

Same scenarios, after:

```
### A.  the note tells the model : []          (nothing announced, nothing promised)
### B.  the note tells the model : ['/uploads/photo.png',
                                    '/uploads/photo.png__thf_bbbb1111',
                                    '/uploads/photo.png__thf_cccc1111']
        each one resolves to its own file
```

One trade-off, stated in the docstring: the listing is a snapshot taken as the
turn starts, while the mount re-queries per tool call. That is the right way
round — an upload INSERTs its `th_files` row before the chat request carries
its `file_key`, so what lands mid-turn is the rename UPDATE (#40), and
anything a snapshot somehow missed is still reachable with `ls`.

## 1.2.2

Version bumped, CHANGELOG entry for #39/#41 and #40/#42 written, and the
1.2.1 entry stops saying "unreleased".

The four READMEs still told readers to run from a source checkout "until 1.2.1
reaches PyPI". 1.2.1 published on 2026-08-23 — `pypi.org/pypi/mirobody/1.2.1`
answers 200 and a bare `pip install mirobody` into a fresh venv gives a working
CLI and an offline four-language resolve — so the warning is now false and it
goes, rather than being re-pointed at 1.2.2. `test_readme_numbers.py` loses its
README half and keeps the CHANGELOG half, which is what its own docstring said
to do when the release landed.

## Gates

```
pytest -q            ->  814 passed, 3 skipped        (full local suite)
pytest -q mirobody   ->  197 passed                   (what a clone runs)
lint-imports         ->  Contracts: 2 kept, 0 broken
python -m build + scripts/check_wheel_data.py
                     ->  1.2.2 wheel and sdist: all 5 engine data bundles
                         present and real; no build-only artifacts shipped
```

And the 1.2.2 wheel installed into a fresh venv, run from outside the source
tree:

```
version: 1.2.2 | from: /private/tmp/mb-v/lib/python3.12/site-packages/mirobody
$ mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)"
  LDL cholesterol  LOINC 13457-7   Cholesterol in LDL [Mass/volume] ...
  血红蛋白          LOINC 718-7     Hemoglobin [Mass/volume] in Blood
  ヘモグロビン       LOINC 718-7     Hemoglobin [Mass/volume] in Blood
  空腹血糖(GLU)     LOINC 1558-6    Fasting glucose [Mass/volume] ...
```

Three regression tests for A, B and the truncation notice went into the local
`tests/` root (gitignored), alongside the ones written while reviewing #41/#42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
