### PR TITLE
Release 1.2.2: units engine backflow and Collect-constant convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,30 @@
 
 ## 1.2.2 — unreleased
 
+### Added
+
+- **`indicator.fhir.units.pick_display_unit`** — pick the unit a merged series
+  displays in: the most frequent unit wins, ties go to the latest measurement.
+  One indicator must render as one series in one unit; this is the tie-break
+  callers were each reimplementing.
+
 ### Fixed
+
+- **`parse_value_unit` respects the author's whitespace boundary.** The
+  whitespace collapse used to glue a numeric value onto a digit-leading count
+  unit: `240 10⁹/L` became `240109/L` and parsed as value 240109, unit `/L` —
+  a platelet count corrupted by three orders of magnitude. The first token is
+  now tried as the whole value and the remainder as the whole unit before any
+  collapsing (Path B0). Golden vectors in `mirobody/test_units.py`.
+
+- **The pulse Collect tables no longer carry conversion constants of their
+  own.** `pulse.standardize.units` had drifted from the UCUM engine it
+  shadows: lb was 2.20462 there vs the exact 2.2046226… ([lb_av] =
+  453.59237 g), glucose said 18.0182 vs the engine's 18.016 (C6H12O6 =
+  180.16 g/mol). Imperial factors and the glucose/cholesterol/triglyceride
+  molar masses now derive from `indicator.fhir.units.convert` at import, and
+  `mirobody/test_units.py` walks the whole table asserting zero drift wherever
+  both sides know the pair.
 
 - **An attachment-only chat turn is a question.** Attaching a file and pressing
   send without typing anything was refused with `-3 Empty question.` before the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Changelog
 
-## 1.2.1 — unreleased
+## 1.2.2 — unreleased
+
+### Fixed
+
+- **An attachment-only chat turn is a question.** Attaching a file and pressing
+  send without typing anything was refused with `-3 Empty question.` before the
+  agent was ever reached — `chat_handler` judged emptiness on the message text
+  alone. It now judges the whole turn, and a turn that carries files but no
+  words is normalised once, at the top of `handle_request`, into a stand-in
+  question in the request's language (`mirobody/utils/locales/chat.json`). One
+  field, so persistence, the session title, the resume hint, the `question`
+  kwarg and the message the model receives all agree; no turn reaches a
+  provider as a zero-length user message, which Anthropic rejects outright and
+  LangGraph would checkpoint into the session and replay. (#39, #41)
+
+- **`/uploads/` paths no longer move under the model mid-turn.** The upload
+  pass asks an LLM for a descriptive filename and overwrites
+  `th_files.file_name` with it, concurrently with the agent — so `ls` listed a
+  file that `read_file` then could not open, and the agent told the user their
+  report was unreadable. `/uploads/` now names this turn's attachments by what
+  the request attached them under, and the note that announces those paths to
+  the model is built from the mount itself rather than from the request, so it
+  cannot name a path the mount does not serve: same-named attachments are
+  announced apart, a `file_key` whose row is deleted or is not the caller's is
+  not announced at all, and a listing shortened by the per-turn file cap says
+  so. `/library/` still shows the stored, descriptive name. (#40, #42)
+
+## 1.2.1 — released 2026-08-23
 
 The first release in which `pip install mirobody` actually works, and the MCP
 surface is on the current protocol. There are **breaking changes to the MCP tool

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,12 +42,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **1.2.1 が PyPI に出るまでは、ソースチェックアウトから実行してほしい**
-> （`git clone` + `git lfs pull` + `pip install -e .`。後述の「一式を動かす」参照）。
-> 公開中の `1.0.62` wheel は空箱だ ―― CLI が無く、リゾルバのデータファイルは
-> 133バイトの Git-LFS ポインタスタブなので、何も解決できない。詳細は
-> [CHANGELOG](CHANGELOG.md)。
-
 <p align="center">
   <img src="docs/images/resolve-demo.ja.gif"
        alt="mirobody resolve：4つの言語が1つのLOINCコードに落ちる、完全オフライン" width="880">

--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **Until 1.2.1 reaches PyPI, run this from a source checkout** (`git clone` +
-> `git lfs pull` + `pip install -e .`, as in [Run the whole thing](#-run-the-whole-thing)):
-> the published `1.0.62` wheel is an empty shell — no CLI, and the resolver data
-> files are 133-byte Git-LFS pointer stubs, so nothing resolves. Details in the
-> [CHANGELOG](CHANGELOG.md).
-
 <p align="center">
   <img src="docs/images/resolve-demo.gif"
        alt="mirobody resolve: four languages landing on one LOINC code, fully offline" width="880">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,11 +42,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **在 1.2.1 发布到 PyPI 之前，请从源码 checkout 运行**（`git clone` +
-> `git lfs pull` + `pip install -e .`，见下文「把整套跑起来」）：当前发布的
-> `1.0.62` wheel 是个空壳——没有 CLI，解析器数据文件只是 133 字节的 Git-LFS
-> 指针 stub，什么都解析不了。详见 [CHANGELOG](CHANGELOG.md)。
-
 <p align="center">
   <img src="docs/images/resolve-demo.zh-CN.gif"
        alt="mirobody resolve：四种语言落到同一个 LOINC 码，完全离线" width="880">

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -42,11 +42,6 @@ pip install mirobody
 mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖(GLU)" 血脂
 ```
 
-> **在 1.2.1 發佈到 PyPI 之前，請從原始碼 checkout 執行**（`git clone` +
-> `git lfs pull` + `pip install -e .`，見下文「把整套跑起來」）：目前發佈的
-> `1.0.62` wheel 是個空殼——沒有 CLI，解析器資料檔只是 133 位元組的 Git-LFS
-> pointer stub，什麼都解析不了。詳見 [CHANGELOG](CHANGELOG.md)。
-
 <p align="center">
   <img src="docs/images/resolve-demo.zh-TW.gif"
        alt="mirobody resolve：四種語言落到同一個 LOINC 碼，完全離線" width="880">

--- a/mirobody/__init__.py
+++ b/mirobody/__init__.py
@@ -19,4 +19,4 @@ try:
     __version__ = _version("mirobody")
 except Exception:
     import os
-    __version__ = os.environ.get("MIROBODY_VERSION") or "1.2.1"
+    __version__ = os.environ.get("MIROBODY_VERSION") or "1.2.2"

--- a/mirobody/agent/deep_agent.py
+++ b/mirobody/agent/deep_agent.py
@@ -866,18 +866,9 @@ class DeepAgent():
             # duplicate that and blow up the context. BaseAgent still uses
             # files_data (it has no virtual FS).
 
-            # Tell the model exactly which files were attached this turn (and
-            # their /uploads/ paths) so it reads them without an ls round-trip and
-            # never misses one. Transient — appended to the run's messages only,
-            # not the cached system prompt. Matches the incoming list's element
-            # type (BaseMessage vs dict) to avoid mixing forms.
-            reminder = _attachment_reminder(file_list)
-            if reminder:
-                if messages and isinstance(messages[-1], BaseMessage):
-                    from langchain_core.messages import HumanMessage
-                    messages = [*messages, HumanMessage(content=reminder)]
-                else:
-                    messages = [*messages, {"role": "user", "content": reminder}]
+            # The attachment reminder is built AFTER the mount exists — see the
+            # append below, and `_attachment_reminder` for why the paths have to
+            # come from the mount rather than from this request.
 
             llm_client, model_name, fallback_msg, loaded_tools, system_prompt = await self._prepare_context(
                 user_id=user_id,
@@ -903,6 +894,19 @@ class DeepAgent():
                 file_list=file_list,
                 supports_file_block=supports_file_block,
             )
+
+            # Tell the model exactly which files this turn attached and where to
+            # read them, so it never needs an `ls /uploads/` round-trip and never
+            # silently misses one. Transient — appended to the run's messages
+            # only, not the cached system prompt. Matches the list's element type
+            # (BaseMessage vs dict) to avoid mixing forms.
+            reminder = await _attachment_reminder(backend, file_list)
+            if reminder:
+                if final_messages and isinstance(final_messages[-1], BaseMessage):
+                    from langchain_core.messages import HumanMessage
+                    final_messages = [*final_messages, HumanMessage(content=reminder)]
+                else:
+                    final_messages = [*final_messages, {"role": "user", "content": reminder}]
 
             token_counter = TokenUsageCallback()
             stream_config = self._create_stream_config(user_id, token_counter, session_id)
@@ -1088,30 +1092,76 @@ class DeepAgent():
         return llm_clients
 
 
-def _attachment_reminder(file_list: list[dict[str, Any]] | None) -> str | None:
-    """A short note naming the files attached to THIS turn and their /uploads/
-    paths, so the model reads them without first having to ``ls /uploads/`` (and
-    never silently misses an attachment). Returns None when nothing is attached.
+async def _attachment_reminder(backend: Any,
+                               file_list: list[dict[str, Any]] | None) -> str | None:
+    """A short note naming this turn's attachments and their `/uploads/` paths,
+    so the model reads them without first having to ``ls /uploads/`` (and never
+    silently misses one). Returns None when nothing readable is attached.
+
+    **The paths come from the MOUNT, never from the request.** Deriving them
+    from the request payload is what issue #40 was: two independent name
+    computations that agreed only for as long as nothing renamed the file
+    mid-turn. Pinning `/uploads/` to the request's names (PR #42) made them
+    agree in the common case, but a request-derived listing can still name a
+    path the mount does not serve, in at least three ways:
+
+    * two attachments share a name — the mount serves the second under a
+      ``__thf_`` suffix the request cannot predict, so a request-derived note
+      announces one path twice and every read lands on the first file;
+    * the row is gone or was never the caller's (deleted, another user's
+      `file_key`) — the projection filters on `user_id` and `is_del`, the
+      request does not, so the note promises a file the mount will refuse;
+    * more than `_MAX_SESSION_FILES` attachments — the mount truncates, and a
+      request-derived note lists files that are not there.
+
+    Every one of those ends the same way for the user: the agent says the
+    upload is unreadable and asks them to send it again. Asking the projection
+    removes the class rather than the instances, and keeps this note correct
+    through any future change to how the mount names a file.
+
+    The listing is a snapshot taken as the turn starts, while the mount
+    re-queries on every tool call. That is the right way round: an upload
+    INSERTs its `th_files` row before the chat request carries its `file_key`,
+    so what lands mid-turn is an UPDATE (the rename), and anything the snapshot
+    somehow missed is still reachable with `ls`.
 
     Injected as a transient message (NOT the system prompt — that is cached and
     must stay stable across turns). Ephemeral: persistence saves the user
     question + assistant reply separately, not this note.
     """
-    items = [f for f in (file_list or []) if isinstance(f, dict) and f.get("file_key")]
-    paths: list[str] = []
-    from .deep.files_backend import _MAX_SESSION_FILES, safe_basename
+    attached = [f for f in (file_list or []) if isinstance(f, dict) and f.get("file_key")]
+    if not attached:
+        return None
 
-    for f in items[:_MAX_SESSION_FILES]:
-        name = safe_basename(f.get("file_name") or str(f.get("file_key")))
-        if name:
-            paths.append(f"/uploads/{name}")
+    # Anonymous sessions get a bare StateBackend with no /uploads/ route, and
+    # nothing to announce; `routes` is what tells the two apart.
+    uploads = getattr(backend, "routes", {}).get("/uploads/")
+    if uploads is None:
+        return None
+
+    # The public listing seam, so this note says exactly what the model's own
+    # `ls /uploads/` would say. A query failure returns no entries (`_files`
+    # logs and degrades); the model then falls back to `ls`, as it did before
+    # this note existed.
+    listed = await uploads.als("/")
+    paths = [f"/uploads{e['path']}" for e in (listed.entries or [])
+             if e.get("path") and not e.get("is_dir")]
     if not paths:
         return None
+
     listing = "\n".join(f"- {p}" for p in paths)
-    return (
-        "[System note: the user attached the following file(s) to THIS message. "
+    note = (
+        "[System note: the user attached file(s) to THIS message. "
         "Read the relevant one(s) with read_file before answering:\n"
-        f"{listing}]"
+        f"{listing}"
     )
+    # Say so rather than quietly listing fewer than were sent: a model that
+    # believes it has seen everything answers about everything.
+    if len(paths) < len(attached):
+        note += (
+            f"\n({len(paths)} of {len(attached)} attached file(s) are readable; "
+            "the rest are not in the user's file store.)"
+        )
+    return note + "]"
 
 

--- a/mirobody/indicator/fhir/units/__init__.py
+++ b/mirobody/indicator/fhir/units/__init__.py
@@ -34,7 +34,7 @@ from .families import (
 )
 from .convert import (
     MOLAR_MASS, conversion_factor, convert_value, convertible, partition_units,
-    scale,
+    pick_display_unit, scale,
 )
 from .normalize import (
     ParsedQuantity, normalize_unit, parse_value_unit, scan_value_units,
@@ -53,6 +53,7 @@ __all__ = [
     "convertible",
     "conversion_factor",
     "partition_units",
+    "pick_display_unit",
     "scale",
     "MOLAR_MASS",
 ]

--- a/mirobody/indicator/fhir/units/convert.py
+++ b/mirobody/indicator/fhir/units/convert.py
@@ -59,6 +59,7 @@ __all__ = [
     "conversion_factor",
     "convert_value",
     "partition_units",
+    "pick_display_unit",
     "MOLAR_MASS",
 ]
 
@@ -270,3 +271,27 @@ def partition_units(units: Iterable[str], *, loinc_code: str = "") -> list[list[
         else:
             classes.append([unit])
     return classes
+
+
+def pick_display_unit(stats: Iterable[tuple[str, int, object]]) -> str:
+    """Display unit = the most frequent one; ties go to the latest measurement.
+
+    One indicator must render as one series in one unit, so the caller
+    converts every reading in a convertible class to the unit this picks.
+    `stats` rows are ``(unit, reading_count, latest_measured_at)`` triples;
+    the timestamp may be None (sorts oldest).
+    """
+    best: tuple[str, int, object] | None = None
+    for unit, count, latest in stats:
+        if not unit:
+            continue
+        if best is None:
+            best = (unit, count, latest)
+            continue
+        if count > best[1]:
+            best = (unit, count, latest)
+        elif count == best[1]:
+            # Same frequency: prefer the most recent measurement; None is oldest.
+            if latest is not None and (best[2] is None or latest > best[2]):
+                best = (unit, count, latest)
+    return best[0] if best else ""

--- a/mirobody/indicator/fhir/units/families.py
+++ b/mirobody/indicator/fhir/units/families.py
@@ -384,8 +384,11 @@ UCUM_FAMILY: dict[str, str] = {
     "mm":       "Len",
     "um":       "Len",
     "km":       "Len",
-    "[in_us]":  "Len",      # inch
-    "[ft_us]":  "Len",      # foot
+    "[in_us]":  "Len",      # inch (US survey — what the aliases resolve to)
+    "[ft_us]":  "Len",      # foot (US survey)
+    "[in_i]":   "Len",      # inch (international, exactly 0.0254 m) — the
+    "[ft_i]":   "Len",      # spelling convert._BASE can actually convert;
+                            # [in_us]/[ft_us] have no _BASE atom and stay atomic
     "[mi_us]":  "Len",      # mile
     "[yd_us]":  "Len",      # yard
 

--- a/mirobody/indicator/fhir/units/normalize.py
+++ b/mirobody/indicator/fhir/units/normalize.py
@@ -279,6 +279,23 @@ def normalize_unit(text: str | None) -> str | None:
 _VALUE_ANYWHERE = re.compile(r"[0-9]+(?:[.,][0-9]+)?")
 
 
+def _comparator_and_value(raw_cmp: str, raw_num: str) -> tuple[str, float | None]:
+    """Split a _VALUE_PREFIX match into (comparator, float value).
+
+    ``-``/``+`` are signs (part of the number), not comparators.
+    """
+    sign = ""
+    if raw_cmp == "-":
+        sign, raw_cmp = "-", ""
+    elif raw_cmp == "+":
+        raw_cmp = ""
+    try:
+        value: float | None = float((sign + raw_num).replace(",", "."))
+    except ValueError:
+        value = None
+    return raw_cmp, value
+
+
 # ``parse_value_unit`` expects a clean ``<value><unit>`` standalone
 # string; resolver / corpus-side users need to find ``75 g`` inside
 # longer text (LOINC names: ``--2 hours post 75 g glucose PO``). The
@@ -436,20 +453,28 @@ def parse_value_unit(text: str | None) -> ParsedQuantity:
     if direct is not None:
         return ParsedQuantity("", None, direct)
 
+    # ── Path B0: respect an explicit whitespace boundary ─────────────
+    # ``_clean`` collapses internal whitespace, which GLUES a numeric value
+    # onto a digit-leading unit: ``240 10⁹/L`` → NFKC ⁹→9 → ``240109/L``,
+    # after which Path B's greedy digit match reads value=240109, unit=/L —
+    # a platelet count corrupted by three orders of magnitude. The author's
+    # own separator is the strongest split signal, so before collapsing it,
+    # try: first token ENTIRELY comparator+number, remainder a unit on its
+    # own. Digit-leading units (10*9/L, 10¹²/L, …) resolve via the alias
+    # table exactly like the bare-unit Path A always has.
+    parts = text.split()
+    if len(parts) >= 2:
+        m0 = _VALUE_PREFIX.fullmatch(_clean(parts[0]))
+        if m0:
+            unit0 = _resolve_strict(_clean("".join(parts[1:])))
+            if unit0 is not None:
+                cmp0, value0 = _comparator_and_value(m0.group(1), m0.group(2))
+                return ParsedQuantity(cmp0, value0, unit0)
+
     # ── Path B: value at start (with optional comparator) ────────────
     m = _VALUE_PREFIX.match(cleaned)
     if m:
-        raw_cmp, raw_num = m.group(1), m.group(2)
-        # ``-``/``+`` are signs (part of the number), not comparators.
-        sign = ""
-        if raw_cmp == "-":
-            sign, raw_cmp = "-", ""
-        elif raw_cmp == "+":
-            raw_cmp = ""
-        try:
-            value: float | None = float((sign + raw_num).replace(",", "."))
-        except ValueError:
-            value = None
+        raw_cmp, value = _comparator_and_value(m.group(1), m.group(2))
         rest = cleaned[m.end():]
         if not rest:
             return ParsedQuantity(raw_cmp, value, None)

--- a/mirobody/pulse/standardize/units.py
+++ b/mirobody/pulse/standardize/units.py
@@ -8,6 +8,14 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, Set, Tuple
 
+# The UCUM engine is the single source for every constant this module shares
+# with it: imperial mass/length definitions and substance molar masses. This
+# table used to carry its own literals and they had already drifted (lb was
+# 2.20462 here vs the NIST-exact 2.2046226… there; glucose said 18.0182 here
+# vs 18.016 there) — two conversions for the same physical fact in one
+# codebase. `mirobody/test_units.py` gates that the drift stays at zero.
+from ...indicator.fhir.units.convert import MOLAR_MASS, conversion_factor
+
 # Import StandardIndicator for type hints
 try:
     from .indicators_info import StandardIndicator
@@ -59,22 +67,21 @@ STANDARD_UNITS: Set[str] = {
 # Where: 1 base_unit = conversion_factor × target_unit
 # Example: 1 kg = 1000 g, so "kg": {"g": 1000}
 _RAW_UNIT_CONVERSIONS: Dict[str, Dict[str, float]] = {
-    # Mass: base unit kg
-    # 1 kg = 1000 g = 2.20462 lb = 35.274 oz
+    # Mass: base unit kg. Imperial factors come from the UCUM engine's exact
+    # definitions ([lb_av] = 453.59237 g), not rounded literals.
     "kg": {
         "g": 1000,
-        "lb": 2.20462,
-        "oz": 35.274,
+        "lb": conversion_factor("kg", "[lb_av]"),
+        "oz": conversion_factor("kg", "[oz_av]"),
     },
 
-    # Length: base unit m
-    # 1 m = 100 cm = 1000 mm = 0.001 km = 3.28084 ft = 39.3701 in
+    # Length: base unit m. ft/in likewise from the engine ([ft_i] = 0.3048 m).
     "m": {
         "cm": 100,
         "mm": 1000,
         "km": 0.001,
-        "ft": 3.28084,
-        "in": 39.3701,
+        "ft": conversion_factor("m", "[ft_i]"),
+        "in": conversion_factor("m", "[in_i]"),
     },
 
     # Time - milliseconds: base unit ms
@@ -320,30 +327,27 @@ def _populate_indicator_specific_conversions():
         }
     }
 
-    # Blood Glucose: standard unit is mg/dL
-    # mmol/L <-> mg/dL conversion (molar mass: ~180 g/mol)
-    # 1 mg/dL = 0.0555 mmol/L
-    # 1 mmol/L = 18.0182 mg/dL
+    # Blood Glucose: standard unit is mg/dL. Molar mass from the engine's
+    # MOLAR_MASS (C6H12O6 = 180.16 g/mol, keyed by LOINC): 1 mmol/L =
+    # 18.016 mg/dL. This block used to say 18.0182 — a fourth-copy drift.
+    glucose_g_per_mol = MOLAR_MASS["2345-7"][0]
     INDICATOR_SPECIFIC_CONVERSIONS[StandardIndicator.BLOOD_GLUCOSE] = {
         "conversions": {
             "mmol/L": {
-                "to_standard": lambda v: v * 18.0182,  # mmol/L -> mg/dL
-                "from_standard": lambda v: v * 0.0555,  # mg/dL -> mmol/L
+                "to_standard": lambda v: v * glucose_g_per_mol / 10.0,  # mmol/L -> mg/dL
+                "from_standard": lambda v: v * 10.0 / glucose_g_per_mol,  # mg/dL -> mmol/L
             }
         }
     }
 
-    # Cholesterol indicators: standard unit is mmol/L
-    # mg/dL <-> mmol/L conversion (molar mass: ~387 g/mol)
-    # 1 mg/dL = 0.02586 mmol/L
-    # 1 mmol/L = 38.67 mg/dL
-    # g/L <-> mmol/L conversion
-    # 1 g/L = 2.586 mmol/L
+    # Cholesterol indicators: standard unit is mmol/L. Molar mass from the
+    # engine's MOLAR_MASS (C27H46O = 386.65 g/mol): 1 mmol/L = 38.665 mg/dL.
     #
     # Triglycerides are NOT in this list. An earlier version applied the
     # cholesterol factor (387 g/mol) to triglycerides too, so TG 150 mg/dL
     # (upper normal) converted to 3.879 mmol/L — read as "severely elevated"
     # instead of the correct ~1.69 mmol/L (a 2.29x error).
+    cholesterol_g_per_mol = MOLAR_MASS["2093-3"][0]
     for cholesterol_indicator in [
         StandardIndicator.CHOLESTEROL_LDL,
         StandardIndicator.CHOLESTEROL_HDL,
@@ -352,30 +356,29 @@ def _populate_indicator_specific_conversions():
         INDICATOR_SPECIFIC_CONVERSIONS[cholesterol_indicator] = {
             "conversions": {
                 "mg/dL": {
-                    "to_standard": lambda v: v * 0.02586,  # mg/dL -> mmol/L
-                    "from_standard": lambda v: v * 38.67,  # mmol/L -> mg/dL
+                    "to_standard": lambda v: v * 10.0 / cholesterol_g_per_mol,  # mg/dL -> mmol/L
+                    "from_standard": lambda v: v * cholesterol_g_per_mol / 10.0,  # mmol/L -> mg/dL
                 },
                 "g/L": {
-                    "to_standard": lambda v: v * 2.586,  # g/L -> mmol/L
-                    "from_standard": lambda v: v * 0.387,  # mmol/L -> g/L
+                    "to_standard": lambda v: v * 1000.0 / cholesterol_g_per_mol,  # g/L -> mmol/L
+                    "from_standard": lambda v: v * cholesterol_g_per_mol / 1000.0,  # mmol/L -> g/L
                 }
             }
         }
 
     # Triglycerides: standard unit is mmol/L, but the molar mass is its own —
-    # a conventional average of ~885.4 g/mol (triolein), the same constant
-    # `indicator/fhir/units/convert.py` uses for LOINC 2571-8.
-    # 1 mg/dL = 10/885.4 = 0.011294 mmol/L
-    # 1 mmol/L = 88.54 mg/dL
+    # the conventional average the engine keys to LOINC 2571-8 (~885.4 g/mol,
+    # triolein): 1 mmol/L = 88.54 mg/dL.
+    tg_g_per_mol = MOLAR_MASS["2571-8"][0]
     INDICATOR_SPECIFIC_CONVERSIONS[StandardIndicator.CHOLESTEROL_TRIGLYCERIDES] = {
         "conversions": {
             "mg/dL": {
-                "to_standard": lambda v: v * (10.0 / 885.4),  # mg/dL -> mmol/L
-                "from_standard": lambda v: v * 88.54,  # mmol/L -> mg/dL
+                "to_standard": lambda v: v * 10.0 / tg_g_per_mol,  # mg/dL -> mmol/L
+                "from_standard": lambda v: v * tg_g_per_mol / 10.0,  # mmol/L -> mg/dL
             },
             "g/L": {
-                "to_standard": lambda v: v * (1000.0 / 885.4),  # g/L -> mmol/L
-                "from_standard": lambda v: v * 0.8854,  # mmol/L -> g/L
+                "to_standard": lambda v: v * 1000.0 / tg_g_per_mol,  # g/L -> mmol/L
+                "from_standard": lambda v: v * tg_g_per_mol / 1000.0,  # mmol/L -> g/L
             }
         }
     }

--- a/mirobody/test_readme_numbers.py
+++ b/mirobody/test_readme_numbers.py
@@ -153,13 +153,17 @@ _EMAIL = re.compile(r"[\w.+-]+@mirobody\.ai")
 _VERSION_SENTINEL = re.compile(r'or "(\d+\.\d+\.\d+)"')
 
 
-def test_the_awaited_version_is_the_source_tree_version():
-    """The READMEs tell readers to run from source "until X reaches PyPI",
-    the CHANGELOG's top entry names the release being prepared, and
-    `mirobody/__init__.py` carries the version the tree calls itself. All
-    three must agree, or a reader waits for a release that will never bear
-    that number. (When the release lands and the READMEs drop the warning,
-    delete the README half of this test; the CHANGELOG half stays.)"""
+def test_the_changelog_names_the_version_the_tree_calls_itself():
+    """The CHANGELOG's top entry names the release being prepared and
+    `mirobody/__init__.py` carries the version the tree calls itself; they
+    must agree, or the release notes describe a number nothing will ship
+    under.
+
+    This used to check a third place: the READMEs told readers to run from a
+    source checkout "until 1.2.1 reaches PyPI", because the published 1.0.62
+    wheel was an empty shell. 1.2.1 published on 2026-08-23, the four READMEs
+    dropped the warning, and this half went with it — as the previous version
+    of this docstring said it should."""
     src = (_ROOT / "mirobody" / "__init__.py").read_text(encoding="utf-8")
     version = _VERSION_SENTINEL.search(src).group(1)
 
@@ -168,14 +172,6 @@ def test_the_awaited_version_is_the_source_tree_version():
     assert top == version, (
         f"CHANGELOG's top entry is {top}; mirobody/__init__.py says {version}"
     )
-
-    for name in _READMES:
-        m = re.search(r"(\d+\.\d+\.\d+)(?= reaches| 发布| 發佈| が PyPI)", _text(name))
-        assert m, f"{name}: the run-from-source warning names no awaited version"
-        assert m.group(1) == version, (
-            f"{name} tells readers to wait for {m.group(1)}; "
-            f"the source tree is {version}"
-        )
 
 
 @pytest.mark.parametrize("name", _READMES)

--- a/mirobody/test_units.py
+++ b/mirobody/test_units.py
@@ -1,0 +1,117 @@
+"""Golden vectors for the units engine's shipped claims (see CHANGELOG 1.2.2).
+
+Three things live here as executable evidence, so a contributor touching
+``_clean``/``parse_value_unit`` or the conversion tables gets a red test
+instead of a silent regression:
+
+* **Path B0** — ``parse_value_unit`` honours the author's whitespace boundary.
+  ``240 10⁹/L`` is a platelet count of 240 in ``10*9/L``; before the fix the
+  whitespace collapse glued the count scale into the value and read 240109/L —
+  off by three orders of magnitude.
+* **pick_display_unit** — the unit a merged series displays in: most readings
+  wins, ties go to the latest measurement.
+* **Convergence guard** — ``pulse.standardize.units`` (device-side Collect)
+  derives every constant it shares with this engine FROM this engine. The two
+  tables had measurably drifted before they were converged: lb was 2.20462
+  there vs the exact 2.2046226… here, glucose 18.0182 vs 18.016. This test
+  walks the whole Collect table and pins the drift at zero wherever both
+  sides know the pair.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from mirobody.indicator.fhir.units import (
+    conversion_factor,
+    normalize_unit,
+    parse_value_unit,
+    pick_display_unit,
+)
+from mirobody.indicator.fhir.units.convert import MOLAR_MASS
+
+
+# ── Path B0: the whitespace boundary is a split signal ──────────────────────
+
+@pytest.mark.parametrize(
+    "text, comparator, value, unit",
+    [
+        # The motivating bug: digit-leading count units after a space.
+        ("240 10^9/L", "", 240.0, "10*9/L"),
+        ("240 10⁹/L", "", 240.0, "10*9/L"),
+        ("4.5 10*12/L", "", 4.5, "10*12/L"),
+        # Ordinary spaced inputs keep parsing exactly as before.
+        ("5.6 mmol/L", "", 5.6, "mmol/L"),
+        ("<5 mg/dL", "<", 5.0, "mg/dL"),
+        # Path A untouched: a whole-input unit never invents a value.
+        ("10*9/L", "", None, "10*9/L"),
+    ],
+)
+def test_parse_value_unit_golden(text, comparator, value, unit):
+    got = parse_value_unit(text)
+    assert (got.comparator, got.value, got.unit) == (comparator, value, unit)
+
+
+# ── pick_display_unit: majority, then recency ────────────────────────────────
+
+def test_pick_display_unit_majority_then_recency():
+    t1 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    t2 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    # Most readings wins outright, even against a newer minority.
+    assert pick_display_unit([("mmol/L", 5, t1), ("mg/dL", 2, t2)]) == "mmol/L"
+    # Ties go to the latest measurement; a None timestamp sorts oldest.
+    assert pick_display_unit([("mmol/L", 3, t1), ("mg/dL", 3, t2)]) == "mg/dL"
+    assert pick_display_unit([("mmol/L", 3, None), ("mg/dL", 3, t1)]) == "mg/dL"
+    # Nothing usable → empty string, not an exception.
+    assert pick_display_unit([]) == ""
+    assert pick_display_unit([("", 9, t2)]) == ""
+
+
+# ── Convergence guard: the Collect tables carry no constants of their own ───
+
+def test_collect_table_has_zero_drift_against_the_engine():
+    from mirobody.pulse.standardize.units import UNIT_CONVERSIONS
+
+    checked = 0
+    drift: list[tuple[str, str, float, float]] = []
+    for src, targets in UNIT_CONVERSIONS.items():
+        ns = normalize_unit(src)
+        if ns is None:
+            continue
+        for dst, factor in targets.items():
+            nd = normalize_unit(dst)
+            if nd is None:
+                continue
+            engine = conversion_factor(ns, nd)
+            if engine is None:
+                continue  # the engine declines (device alias, atomic unit)
+            checked += 1
+            if abs(engine - factor) > 1e-12 * max(abs(engine), abs(factor)):
+                drift.append((src, dst, factor, engine))
+    assert not drift, f"Collect table disagrees with the engine: {drift}"
+    # Guard the guard: if normalize_unit stops resolving these spellings the
+    # loop silently checks nothing and this test would pass vacuously.
+    assert checked >= 90, f"only {checked} pairs were comparable"
+
+
+def test_substance_factors_come_from_molar_mass():
+    from mirobody.pulse.standardize import StandardIndicator
+    from mirobody.pulse.standardize.units import INDICATOR_SPECIFIC_CONVERSIONS
+
+    glucose = MOLAR_MASS["2345-7"][0]
+    chol = MOLAR_MASS["2093-3"][0]
+    tg = MOLAR_MASS["2571-8"][0]
+
+    gl = INDICATOR_SPECIFIC_CONVERSIONS[StandardIndicator.BLOOD_GLUCOSE]["conversions"]
+    assert gl["mmol/L"]["to_standard"](1.0) == pytest.approx(glucose / 10.0)
+
+    ldl = INDICATOR_SPECIFIC_CONVERSIONS[StandardIndicator.CHOLESTEROL_LDL]["conversions"]
+    assert ldl["mg/dL"]["to_standard"](1.0) == pytest.approx(10.0 / chol)
+    assert ldl["g/L"]["from_standard"](1.0) == pytest.approx(chol / 1000.0)
+
+    trig = INDICATOR_SPECIFIC_CONVERSIONS[StandardIndicator.CHOLESTEROL_TRIGLYCERIDES]["conversions"]
+    assert trig["mg/dL"]["from_standard"](1.0) == pytest.approx(tg / 10.0)
+    # The 2.29x lesson stays pinned: TG must NOT use the cholesterol factor.
+    assert trig["mg/dL"]["to_standard"](150.0) == pytest.approx(1.694, abs=1e-3)


### PR DESCRIPTION
## What's in 1.2.2

### Units engine

- **`indicator.fhir.units.pick_display_unit`** (new) — pick the unit a merged
  series displays in: most readings wins, ties go to the latest measurement.
  One indicator must render as one series in one unit; this is the tie-break
  callers were each reimplementing.
- **`parse_value_unit` respects the author's whitespace boundary (Path B0).**
  The whitespace collapse used to glue a numeric value onto a digit-leading
  count unit: `240 10⁹/L` became `240109/L` and parsed as value 240109,
  unit `/L` — a platelet count corrupted by three orders of magnitude. The
  first token is now tried as the whole value and the remainder as the whole
  unit before any collapsing.
- **The pulse Collect tables no longer carry conversion constants of their
  own.** `pulse.standardize.units` had drifted from the UCUM engine it
  shadows: lb was `2.20462` there vs the exact `2.2046226…` (`[lb_av]` =
  453.59237 g), glucose said `18.0182` vs the engine's `18.016` (C6H12O6 =
  180.16 g/mol). Imperial factors and the glucose / cholesterol /
  triglyceride molar masses now derive from `indicator.fhir.units.convert`
  at import. Device-only vocabulary (temperature affine, psi, rmssd, spo2
  aliases) stays local because the engine deliberately declines it.
- **`families.py` gains `[in_i]`/`[ft_i]` rows.** `scale()` gates on
  `UCUM_FAMILY`, and only the international spellings have `_BASE` atoms —
  without the rows the exact ft/in definitions were unreachable by any
  caller.
- **`mirobody/test_units.py`** ships the guardrails in-tree: Path B0 platelet
  vectors, the `pick_display_unit` tie-break, a zero-drift walk of the whole
  Collect table against the engine, and the substance factors pinned to
  `MOLAR_MASS`.

### Agent

- The note announcing this turn's uploads to the model is built from the
  mount itself rather than from the request, so it cannot name a path the
  mount does not serve (follow-up to #40 / #42; details in the CHANGELOG).

### Docs / release

- Version 1.2.2. The four READMEs drop the run-from-source warning that
  publishing 1.2.1 made obsolete.

## Verification

- 206 shipped tests green (including the new `test_units.py`); full local
  suite 835 green.
- `lint-imports`: both contracts kept (engine stays framework-free).
- `python -m build` + `scripts/check_wheel_data.py`: all 5 engine data
  bundles present and real, no build-time-only artifacts shipped.

## Known follow-up (deliberately not in this PR)

`[in_us]`/`[ft_us]` — what the everyday `ft`/`in` aliases resolve to — still
have no `_BASE` atom, so imperial length stays atomic for those spellings.
Giving them exact survey definitions (or retargeting the aliases to the
international units) is a behavior change that deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
