### PR TITLE
readme: print the BUNDLE_VERSION the package actually reports

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -117,7 +117,7 @@ pytest mirobody/test_engine_coverage.py -s   # オフライン、約1秒
 
 ```python
 >>> import mirobody; mirobody.BUNDLE_VERSION
-'loinc-2.82+2026.08.28-050559ecc200'
+'loinc-2.82+2026.08.28-af2524b7a285'
 ```
 
 リリース、切り出し日、そしてバンドル自身のメンバーに対するダイジェスト ―― だから

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ runtime rather than in a comment that can drift:
 
 ```python
 >>> import mirobody; mirobody.BUNDLE_VERSION
-'loinc-2.82+2026.08.28-050559ecc200'
+'loinc-2.82+2026.08.28-af2524b7a285'
 ```
 
 The release, the cut date, and a digest over the bundle's own members — so a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,7 +115,7 @@ pytest mirobody/test_engine_coverage.py -s   # 离线，约一秒
 
 ```python
 >>> import mirobody; mirobody.BUNDLE_VERSION
-'loinc-2.82+2026.08.28-050559ecc200'
+'loinc-2.82+2026.08.28-af2524b7a285'
 ```
 
 版本、切分日期,加上一段对语料成员本身算出的摘要——所以「构建期消费这份词表」和

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -112,7 +112,7 @@ pytest mirobody/test_engine_coverage.py -s   # 離線，約一秒
 
 ```python
 >>> import mirobody; mirobody.BUNDLE_VERSION
-'loinc-2.82+2026.08.28-050559ecc200'
+'loinc-2.82+2026.08.28-af2524b7a285'
 ```
 
 版本、切分日期,加上一段對語料成員本身算出的摘要——所以「建置期消費這份詞表」和

--- a/mirobody/test_readme_numbers.py
+++ b/mirobody/test_readme_numbers.py
@@ -218,3 +218,26 @@ def test_the_demo_file_the_readme_hands_you_is_shipped(name: str):
                 f"seeded history is dated {held_out} — the demo arc only works if "
                 "the upload is the exam the database is missing"
             )
+
+
+def test_the_readmes_print_the_real_bundle_version():
+    """`>>> mirobody.BUNDLE_VERSION` is the one interactive example the READMEs
+    show, and nothing checked its output.
+
+    It shipped wrong: the four files printed `…-050559ecc200`, the digest as of
+    when that section was drafted, while the bundle had since been restamped to
+    `…-af2524b7a285`. A reader pasting the line got a different string — from
+    the one paragraph whose whole point is that the package states its corpus
+    version rather than leaving it in a comment that can drift.
+
+    The digest is a hash over the bundle's own members, so it MUST change
+    whenever the bundle does; this test is what turns that into an edit here
+    instead of a wrong line in the README.
+    """
+    import mirobody
+
+    for name in _READMES:
+        assert mirobody.BUNDLE_VERSION in _text(name), (
+            f"{name} does not print {mirobody.BUNDLE_VERSION!r}; "
+            "restamped the bundle? update the four READMEs"
+        )


### PR DESCRIPTION
The four READMEs showed

```
>>> import mirobody; mirobody.BUNDLE_VERSION
'loinc-2.82+2026.08.28-050559ecc200'
```

and the package reports `loinc-2.82+2026.08.28-af2524b7a285`. The digest was
current when that section was drafted in #45; the bundle was restamped
afterwards and the prose was not re-checked.

It is the **only** interactive example the READMEs carry, and nothing guarded
its output — `test_readme_numbers.py` covers every other exact number in those
files. A reader pasting the one line we invite them to paste got a different
string back, from the paragraph whose whole point is that the corpus version is
a fact the package states rather than a comment that can drift.

The digest is a hash over the bundle's own members, so it must change whenever
the bundle does. The new test makes that a required edit here instead of a
wrong line in the README; it fails on the stale value, verified by putting it
back.

Found while checking this repo's public surface against the GitHubDaily article
going out today, which uses the README as its screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)