### PR TITLE
release: let a failed PyPI upload fail the release

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -50,6 +50,8 @@ jobs:
 
     # Install package dependencies for testing
     # The quality gate. Both steps below used to carry `continue-on-error: true`,
+    # and so did the PyPI upload itself until 1.3.0 — see the note beside the
+    # verify step at the bottom for how that one played out.
     # so nothing in this workflow could fail a release on a code defect — the
     # only hard gates were packaging ones (LFS bundles, langchain-free wheel).
     # 1.0.62 shipped a wheel that resolved no indicators at all; the suite is
@@ -243,7 +245,29 @@ jobs:
       run: |
         echo "Uploading to PyPI..."
         twine upload --repository pypi dist/*
-      continue-on-error: true
+
+    # The upload having "succeeded" is twine's opinion. This asks PyPI.
+    #
+    # 1.2.1 was released twice and neither release existed. Both runs were
+    # GREEN: the upload failed, `continue-on-error` swallowed it, the workflow
+    # carried on and reported success, and the only way anyone found out was
+    # querying PyPI by hand. That `continue-on-error` is gone from the step
+    # above — an upload that fails now fails the job, so no GitHub Release is
+    # cut for a version that is not on PyPI — but "the step exited 0" is still
+    # a weaker claim than "the version is there". Ask for the strong one.
+    - name: Verify the version is actually on PyPI
+      if: (startsWith(github.ref, 'refs/tags/') || github.event_name == 'release') && github.event.inputs.test_mode != 'true'
+      run: |
+        for i in $(seq 1 12); do
+          if curl -sfo /dev/null "https://pypi.org/pypi/mirobody/$VERSION/json"; then
+            echo "PyPI has mirobody $VERSION"
+            exit 0
+          fi
+          echo "not visible yet, retrying in 10s ($i/12)"
+          sleep 10
+        done
+        echo "::error::mirobody $VERSION is not on PyPI two minutes after upload"
+        exit 1
 
     # Create or update GitHub Release (upload build artifacts)
     - name: Upload to GitHub Release


### PR DESCRIPTION
**Blocks tagging 1.3.0.** Found while running the pre-release check.

`Publish to PyPI` still carried `continue-on-error: true` — the exact mechanism
behind both failed 1.2.1 releases:

> the upload failed → the flag swallowed it → the workflow finished **green** →
> a GitHub Release was cut for a version that did not exist → the only way
> anyone found out was querying PyPI by hand.

The fixes at the time (#37, #38) went after what made the upload *fail* (a
polluted global env, then a stale import) and left the flag that turned those
failures into *silence*. The comment at the top of the file says "Both steps
below used to carry `continue-on-error: true`", which reads like the workflow
had been cleared of it. Two steps had; the one that publishes had not.

## Changes

- **`Publish to PyPI` can fail the job.** No GitHub Release is cut for a
  version that is not on PyPI.
- **New step: `Verify the version is actually on PyPI`.** An upload exiting 0
  is twine's opinion; this asks `pypi.org/pypi/mirobody/$VERSION/json` for a
  200, polling two minutes because the index lags the upload. It turns "check
  PyPI by hand after every release, don't trust the workflow's face" from a
  habit someone has to remember into a step that fails.
- **TestPyPI keeps its flag** — that upload already ends in `|| echo`, a
  duplicate filename on a re-run is expected, and nobody installs from it.

Verified the YAML parses and that `Publish to PyPI` now resolves to
`continue-on-error=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)