### PR TITLE
readme: say what Mirobody runs in production, in all four editions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,8 @@
 
 **AIネイティブな健康データエンジン ―― 検査値・ウェアラブル・ゲノムを収集し、標準化し、そこから推論する。**
 
+Mirobody は、5,000+ の登録ユーザーと 500+ のデイリーアクティブユーザーを持つ稼働中のコンシューマー向け健康プロダクト **Theta Wellness** を動かしている。
+
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **The AI-native health data engine — collect, standardize, and reason over labs, wearables & genomics.**
 
+Mirobody powers **Theta Wellness**, a live consumer health product used by 5,000+ registered users with 500+ daily active users.
+
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,8 @@
 
 **AI 原生的健康数据引擎——收集、标准化，并针对检验报告、穿戴设备与基因数据进行推理。**
 
+Mirobody 正在支撑 **Theta Wellness**——一款已上线的消费级健康产品，拥有 5,000+ 注册用户、500+ 日活用户。
+
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,6 +4,8 @@
 
 **AI 原生的健康資料引擎——收集、標準化，並針對檢驗報告、穿戴裝置與基因體資料進行推理。**
 
+Mirobody 正在支撐 **Theta Wellness**——一款已上線的消費級健康產品，擁有 5,000+ 註冊使用者、500+ 日活使用者。
+
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)


### PR DESCRIPTION
Adds one line directly under the tagline in all four README editions,
per the requested wording:

> Mirobody powers **Theta Wellness**, a live consumer health product used by
> 5,000+ registered users with 500+ daily active users.

Localized for 简体中文 / 繁體中文 / 日本語, matching each edition's existing
punctuation and register. Placed above the badges: a reader landing on an
engine repo cannot tell from the code whether anything actually runs on it.

## Notes

- **The two figures are not verifiable from this repo.** They are the owner's
  numbers. `test_readme_numbers` gates only figures this repo can derive
  (alias counts, resolver score) and exempts approximations by design, so
  nothing will catch these going stale — they need a human when they change.
- `Theta Wellness` is the name the product's own outbound mail uses
  (`mirobody/user/email.py`, `user_service.py`), so it is consistent with the
  code; `Theta Health` in the footer stays the company.
- No link on the product name: the repo does not record a canonical
  Theta Wellness URL, and guessing one would be a claim I cannot check.
- README gates: `test_readme_links`, `test_readme_l10n`, `test_readme_numbers`,
  `test_readme_examples` → 47 passed (zh-TW introduces no Simplified
  characters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)