### PR TITLE
readme: say "powers" the way Chinese and Japanese READMEs say it

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 **AIネイティブな健康データエンジン ―― 検査値・ウェアラブル・ゲノムを収集し、標準化し、そこから推論する。**
 
-Mirobody は、5,000+ の登録ユーザーと 500+ のデイリーアクティブユーザーを持つ稼働中のコンシューマー向け健康プロダクト **Theta Wellness** を動かしている。
+稼働中のコンシューマー向け健康プロダクト **Theta Wellness** は、Mirobody の上で動いている ―― 登録ユーザー 5,000+、DAU 500+。
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 **AI 原生的健康数据引擎——收集、标准化，并针对检验报告、穿戴设备与基因数据进行推理。**
 
-Mirobody 正在支撑 **Theta Wellness**——一款已上线的消费级健康产品，拥有 5,000+ 注册用户、500+ 日活用户。
+已上线的消费级健康产品 **Theta Wellness** 由 Mirobody 驱动——注册用户 5,000+，日活 500+。
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,7 +4,7 @@
 
 **AI 原生的健康資料引擎——收集、標準化，並針對檢驗報告、穿戴裝置與基因體資料進行推理。**
 
-Mirobody 正在支撐 **Theta Wellness**——一款已上線的消費級健康產品，擁有 5,000+ 註冊使用者、500+ 日活使用者。
+已上線的消費者健康產品 **Theta Wellness** 由 Mirobody 驅動——註冊使用者 5,000+，每日活躍 500+。
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)


### PR DESCRIPTION
Reopens #50, which was closed by accident — GitHub refused `gh pr reopen`
because that PR's recorded head (`b466705`) was amended away by a
force-push, so it is no longer reachable from the branch. Same branch, same
commit `8f1ed59`, same content.

Follow-up to #49. The three translations read as carried-across English —
`支撑` / `動かしている` is what "powers" turns into word by word.

| | Before (#49) | After |
| --- | --- | --- |
| zh-CN | Mirobody 正在支撑 **Theta Wellness**——一款已上线的消费级健康产品，拥有 5,000+ 注册用户、500+ 日活用户。 | 已上线的消费级健康产品 **Theta Wellness** 由 Mirobody 驱动——注册用户 5,000+，日活 500+。 |
| zh-TW | Mirobody 正在支撐 **Theta Wellness**——…擁有 5,000+ 註冊使用者、500+ 日活使用者。 | 已上線的消費者健康產品 **Theta Wellness** 由 Mirobody 驅動——註冊使用者 5,000+，每日活躍 500+。 |
| ja | Mirobody は、5,000+ の登録ユーザーと…を持つ稼働中の…プロダクト **Theta Wellness** を動かしている。 | 稼働中のコンシューマー向け健康プロダクト **Theta Wellness** は、Mirobody の上で動いている ―― 登録ユーザー 5,000+、DAU 500+。 |

English is unchanged: it was the approved copy.

## Why `由 … 驱动`, and not the words that suggest themselves

Measured, not guessed — GitHub code search over `filename:README.zh-CN.md`:

| phrasing | hits in Chinese READMEs |
| --- | --- |
| `驱动的` | **301** |
| `支撑` | 129 |
| `跑在` | 128 |
| `赋能` | 100 |
| `就跑在` | 9 |
| `技术底座` | **1** |

`赋能` and `底座` are both on the Buzzword Blocklist in
[luoling8192/technical-writing](https://github.com/luoling8192/technical-writing)
— *"让句子看起来有信息，但读完不知道发生了什么"*, with `底座 → 基础设施层是 X`
— and neither says which layer the engine actually is.

Japanese takes a different construction on purpose: it has no idiomatic passive
for 由…驱动, and `駆動` would be the very word-by-word carry-across this PR
removes.

## Per-locale, not one translation pasted three times

- **zh-TW**: `消費者` over `消費級`, `每日活躍` over `日活` (Taiwanese usage),
  keeping `使用者`.
- **zh-CN**: the native short form `日活`; `500+ 日活用户` was calqued word order.

## Verification

- Punctuation checked against each file: EM DASH doubled in the zh files,
  HORIZONTAL BAR doubled in ja — same codepoints as each edition's own tagline
  — and ASCII-comma thousands, as all four already write numbers.
- `pytest mirobody -q` → **275 passed**, including all four README gates; zh-TW
  introduces no Simplified characters.
- The 5,000+ / 500+ figures are untouched and still not verifiable from this
  repo — the owner's numbers, ungated by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)