### PR TITLE
llm: honor <PROVIDER>_BASE_URL everywhere, add <PROVIDER>_MODEL (fixes #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`<PROVIDER>_BASE_URL` now reaches vision/file parsing and structured
+  extraction** ([#52](https://github.com/thetahealth/mirobody/issues/52)).
+  `OPENROUTER_BASE_URL` redirected embeddings but the file-extraction clients
+  were built from a hardcoded table, so an upload's OCR still called
+  `openrouter.ai` and failed against self-hosted gateways — the file saved,
+  but no indicators appeared. All OpenAI-compatible clients (OpenRouter,
+  DashScope, OpenAI, Volcengine) now honor their `<PROVIDER>_BASE_URL`;
+  `OPENAI_BASE_URL` also works from config, not just the environment.
+
+### Added
+
+- **`<PROVIDER>_MODEL`** picks the chat/structured-extraction model per
+  provider, mirroring the existing `<PROVIDER>_VISION_MODEL` — needed when a
+  redirected endpoint does not serve the provider's default model id.
+
 ## 1.3.0
 
 **Breaking, and the whole point: `pip install mirobody` is now a library.** It

--- a/config.yaml
+++ b/config.yaml
@@ -279,6 +279,19 @@ GOOGLE_API_KEY: ""
 OPENAI_API_KEY: ""
 OPENROUTER_API_KEY: ""
 
+# Any OpenAI-compatible provider can be redirected to a self-hosted or proxy
+# endpoint with `<PROVIDER>_BASE_URL` (OPENROUTER_BASE_URL, DASHSCOPE_BASE_URL,
+# OPENAI_BASE_URL, …) — chat, vision/file parsing, structured extraction and
+# embeddings all follow it. If the endpoint does not serve the default model
+# ids, pick the models with `<PROVIDER>_MODEL` (chat/structured extraction)
+# and `<PROVIDER>_VISION_MODEL` (image/PDF parsing). Example — everything
+# through DashScope while keeping the OpenRouter-style one-key setup:
+#   OPENROUTER_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
+#   OPENROUTER_MODEL: qwen-flash
+#   OPENROUTER_VISION_MODEL: qwen3-vl-flash
+# The endpoint must tolerate the provider's request dialect (extra_body flags
+# such as OpenRouter's `reasoning`); gateways like LiteLLM/one-api do.
+
 # DashScope (OpenAI-compatible) API key — the fallback one-key path for
 # networks where openrouter.ai is unreachable (mainland China being the
 # common case). Covers chat (Qwen/DeepSeek/Kimi/GLM), vision (qwen3-vl,

--- a/mirobody/test_one_key_defaults.py
+++ b/mirobody/test_one_key_defaults.py
@@ -150,3 +150,50 @@ def test_a_self_hosted_base_url_override_is_honored(monkeypatch):
     monkeypatch.delenv("OPENROUTER_BASE_URL")
     assert Config(yaml_filenames=str(_CONFIG)).get_llm(LLMProvider.OPENROUTER).base_url \
         == "https://openrouter.ai/api/v1", "unset override must fall back to the gateway"
+
+
+def test_base_url_override_reaches_the_file_extraction_clients(monkeypatch):
+    """Issue #52: the override above redirected embeddings, but the vision /
+    structured-extraction clients were built from AIConfig's hardcoded table —
+    an upload's OCR still called openrouter.ai and the report produced no
+    indicators. Pin every OpenAI-compatible construction path to the same
+    `<PROVIDER>_BASE_URL` rule, and the fallback when it is unset."""
+    import mirobody.utils.config.config as cfg_mod
+    from mirobody.utils.config.config import Config
+    from mirobody.utils.llm.clients import AIClientManager
+    from mirobody.utils.llm.file_processors.backends_openai import (
+        _get_openrouter_client,
+        _get_qwen_client,
+    )
+
+    monkeypatch.setattr(cfg_mod, "_global_config", cfg_mod._global_config)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-ds-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oa-test")
+    for env, url in (
+        ("OPENROUTER_BASE_URL", "http://gateway.internal:8000/v1"),
+        ("DASHSCOPE_BASE_URL",  "http://gateway.internal:8001/v1"),
+        ("OPENAI_BASE_URL",     "http://gateway.internal:8002/v1"),
+    ):
+        monkeypatch.setenv(env, url)
+    Config(yaml_filenames=str(_CONFIG))
+
+    def base(client):
+        return str(client.base_url).rstrip("/")
+
+    # The exact constructors the vision path calls (fresh manager: the module
+    # singleton caches clients from whatever env earlier tests left behind).
+    manager = AIClientManager()
+    assert base(_get_openrouter_client()) == "http://gateway.internal:8000/v1"
+    assert base(_get_qwen_client()) == "http://gateway.internal:8001/v1"
+    assert base(manager.get_async_dashscope_client()) == "http://gateway.internal:8001/v1"
+    assert base(manager.get_async_openai_client()) == "http://gateway.internal:8002/v1", \
+        "OPENAI_BASE_URL must work from config too, not only as the SDK env var"
+
+    for env in ("OPENROUTER_BASE_URL", "DASHSCOPE_BASE_URL", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(env)
+    manager = AIClientManager()
+    assert base(_get_openrouter_client()) == "https://openrouter.ai/api/v1"
+    assert base(_get_qwen_client()) == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    assert base(manager.get_async_openai_client()) == "https://api.openai.com/v1", \
+        "unset override must fall back to each provider's own gateway"

--- a/mirobody/utils/llm/clients.py
+++ b/mirobody/utils/llm/clients.py
@@ -24,16 +24,20 @@ class AIClientManager:
         if self._initialized:
             return
         
-        dashscope_api_key = safe_read_cfg("DASHSCOPE_API_KEY")
-        if dashscope_api_key:
-            self._clients["dashscope"] = OpenAI(api_key=dashscope_api_key,base_url="https://dashscope.aliyuncs.com/compatible-mode/v1")
-            self._async_clients["dashscope"] = AsyncOpenAI(api_key=dashscope_api_key,base_url="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        dashscope_config = AIConfig.get_provider_config("dashscope")
+        if dashscope_config["api_key"]:
+            self._clients["dashscope"] = OpenAI(api_key=dashscope_config["api_key"], base_url=dashscope_config["api_base"])
+            self._async_clients["dashscope"] = AsyncOpenAI(api_key=dashscope_config["api_key"], base_url=dashscope_config["api_base"])
 
-        # OpenAI client
+        # OpenAI client. base_url passed explicitly: the bare constructor reads
+        # only the OPENAI_BASE_URL *environment variable*, so an override set in
+        # config.yaml alone was silently ignored while every other provider's
+        # `<PROVIDER>_BASE_URL` worked. `or None` keeps the SDK default when unset.
         openai_api_key = safe_read_cfg("OPENAI_API_KEY")
         if openai_api_key:
-            self._clients["openai"] = OpenAI(api_key=openai_api_key)
-            self._async_clients["openai"] = AsyncOpenAI(api_key=openai_api_key)
+            openai_base_url = safe_read_cfg("OPENAI_BASE_URL") or None
+            self._clients["openai"] = OpenAI(api_key=openai_api_key, base_url=openai_base_url)
+            self._async_clients["openai"] = AsyncOpenAI(api_key=openai_api_key, base_url=openai_base_url)
 
         # Google Gemini client — lock to AI Studio backend; without vertexai=False,
         # GOOGLE_GENAI_USE_VERTEXAI=true in env reroutes requests to aiplatform with
@@ -99,6 +103,12 @@ class AIClientManager:
 
         return OpenAI(api_key=config["api_key"], base_url=config["api_base"])
 
+    def get_async_ai_client(self, provider: str) -> AsyncOpenAI:
+        """Create async AI client for specified provider (OpenAI-compatible)"""
+        config = AIConfig.get_provider_config(provider)
+
+        return AsyncOpenAI(api_key=config["api_key"], base_url=config["api_base"])
+
     def get_openai_client(self) -> OpenAI:
         """Get OpenAI client"""
         return self.get_client("openai")
@@ -156,14 +166,6 @@ class AIClientManager:
             client = self.get_vertex_gemini_client()
             self._async_clients["vertex_gemini"] = client.aio
         return self._async_clients["vertex_gemini"]
-
-    def get_async_openrouter_client(self) -> AsyncOpenAI:
-        """Get async OpenRouter client (OpenAI-compatible)"""
-        config = AIConfig.get_provider_config("openrouter")
-        return AsyncOpenAI(
-            api_key=config["api_key"],
-            base_url=config["api_base"]
-        )
 
     def is_client_available(self, provider: str) -> bool:
         """Whether an async client for `provider` was successfully constructed."""

--- a/mirobody/utils/llm/config.py
+++ b/mirobody/utils/llm/config.py
@@ -153,6 +153,13 @@ class AIConfig:
             "api_path": "/chat/completions",
             "type": "openai",
         },
+        "dashscope": {
+            "model": "qwen-flash",
+            "api_key_env": "DASHSCOPE_API_KEY",
+            "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "api_path": "/chat/completions",
+            "type": "openai",
+        },
     }
 
     @classmethod
@@ -164,6 +171,16 @@ class AIConfig:
         config = cls._CONFIG[provider].copy()
         # Dynamically get API key
         config["api_key"] = safe_read_cfg(config["api_key_env"])
+        # `<PROVIDER>_BASE_URL` redirects the provider to any OpenAI-compatible
+        # endpoint — the rule Config.get_llm() already applies and config.yaml
+        # documents. Issue #52: embeddings honored OPENROUTER_BASE_URL while
+        # file extraction, built from this table, still called openrouter.ai,
+        # so a self-hosted gateway got the text requests but never the vision
+        # ones. `or` (not a default arg) so an empty env var also falls back.
+        config["api_base"] = (
+            safe_read_cfg(config["api_key_env"].replace("_API_KEY", "_BASE_URL"))
+            or config["api_base"]
+        )
         return config
 
     @classmethod

--- a/mirobody/utils/llm/file_processors/backends_openai.py
+++ b/mirobody/utils/llm/file_processors/backends_openai.py
@@ -21,8 +21,6 @@ from openai import AsyncOpenAI
 if TYPE_CHECKING:
     from volcenginesdkarkruntime import AsyncArk
 
-from mirobody.utils.config import safe_read_cfg
-
 from ..config import AIConfig
 from .media import (
     _build_vision_message,
@@ -173,18 +171,14 @@ def _get_openrouter_client() -> AsyncOpenAI:
     # extraction, which is the README's headline "one LLM key" command.
     from ..clients import client_manager
 
-    return client_manager.get_async_openrouter_client()
+    return client_manager.get_async_ai_client("openrouter")
 
 
 def _get_qwen_client() -> AsyncOpenAI:
     """Get Qwen client (OpenAI compatible)."""
-    api_key = safe_read_cfg("DASHSCOPE_API_KEY")
-    if not api_key:
-        raise ValueError("DASHSCOPE_API_KEY not configured")
-    return AsyncOpenAI(
-        api_key=api_key,
-        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-    )
+    from ..clients import client_manager
+
+    return client_manager.get_async_ai_client("dashscope")
 
 
 def _get_doubao_client() -> "AsyncArk":

--- a/mirobody/utils/llm/file_processors/dispatch.py
+++ b/mirobody/utils/llm/file_processors/dispatch.py
@@ -45,7 +45,6 @@ class VisionProviderConfig:
             "name": "qwen",
             "api_key_env": "DASHSCOPE_API_KEY",
             "default_model": "qwen3-vl-flash",
-            "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
             "description": "Qwen Vision (Alibaba Dashscope)",
         },
         {

--- a/mirobody/utils/llm/utils.py
+++ b/mirobody/utils/llm/utils.py
@@ -263,7 +263,7 @@ async def async_get_structured_output(
                 if prov_name == "openai":
                     client = client_manager.get_async_openai_client()
                 else:
-                    client = client_manager.get_async_openrouter_client()
+                    client = client_manager.get_async_ai_client("openrouter")
 
                 # OpenAI newer models (GPT-4o+) use max_completion_tokens instead of max_tokens
                 provider_kwargs = {**kwargs}
@@ -372,7 +372,7 @@ async def async_get_structured_output(
         if not safe_read_cfg(provider_info["api_key_env"]):
             logging.error(f"Provider {provider} API Key not configured")
             return None
-        actual_model = model_name or provider_info["default_model"]
+        actual_model = model_name or safe_read_cfg(f"{provider.upper()}_MODEL") or provider_info["default_model"]
         logging.info(f"🔄 async_get_structured_output: Using {provider} provider, model: {actual_model}")
         return await _call_provider(provider, actual_model)
     else:
@@ -382,7 +382,12 @@ async def async_get_structured_output(
             if not safe_read_cfg(p["api_key_env"]):
                 continue
             prov_name = p["name"]
-            prov_model = p["default_model"]
+            # `<PROVIDER>_MODEL` overrides the default, mirroring
+            # `<PROVIDER>_VISION_MODEL` on the vision path. Needed whenever
+            # `<PROVIDER>_BASE_URL` points at a gateway that does not serve
+            # the default model id (e.g. OpenRouter redirected to DashScope:
+            # `google/gemini-3-flash-preview` 404s there).
+            prov_model = safe_read_cfg(f"{prov_name.upper()}_MODEL") or p["default_model"]
             logging.info(f"🔄 async_get_structured_output: Trying {prov_name} provider, model: {prov_model}")
             result = await _call_provider(prov_name, prov_model)
             if result is not None:
@@ -435,20 +440,20 @@ async def async_get_text_completion(
     """
     import time
     from .clients import client_manager
-    
+    from mirobody.utils.config import safe_read_cfg
+
     start_time = time.time()
-    
+
     # Determine provider to use
     if provider:
         provider_info = AIConfig.get_provider_by_priority_name(provider)
         if not provider_info:
             logging.error(f"Unknown provider: {provider}")
             return None
-        from mirobody.utils.config import safe_read_cfg
         if not safe_read_cfg(provider_info["api_key_env"]):
             logging.error(f"Provider {provider} API Key not configured")
             return None
-        actual_model = model_name or provider_info["default_model"]
+        actual_model = model_name or safe_read_cfg(f"{provider.upper()}_MODEL") or provider_info["default_model"]
     else:
         provider_info = AIConfig.get_available_provider()
         if not provider_info:
@@ -456,7 +461,8 @@ async def async_get_text_completion(
             logging.error(f"No available AI provider, please configure API Key: {status}")
             return None
         provider = provider_info["name"]
-        actual_model = provider_info["default_model"]
+        # Same `<PROVIDER>_MODEL` override as async_get_structured_output.
+        actual_model = safe_read_cfg(f"{provider.upper()}_MODEL") or provider_info["default_model"]
         if model_name:
             logging.warning(f"⚠️ model_name='{model_name}' ignored, using provider default model: {actual_model}")
     
@@ -468,7 +474,7 @@ async def async_get_text_completion(
             if provider == "openai":
                 client = client_manager.get_async_openai_client()
             elif provider == "openrouter":
-                client = client_manager.get_async_openrouter_client()
+                client = client_manager.get_async_ai_client("openrouter")
             else:
                 client = client_manager.get_async_dashscope_client()
             


### PR DESCRIPTION
Fixes #52.

## What was broken

`OPENROUTER_BASE_URL` redirected embeddings (`Config.get_llm`) but the vision and structured-extraction clients were built from `AIConfig`'s hardcoded table — an upload's OCR still called `openrouter.ai` and failed against self-hosted gateways. The file saved, no indicators appeared, exactly as reported. Reproduced against a recording local gateway: before the fix the configured endpoint received **zero** requests while the extraction returned empty.

## The fix

One rule at one choke point, no merging of the two config families:

- `AIConfig.get_provider_config` overlays `<PROVIDER>_BASE_URL` onto the table's `api_base` — openrouter (vision + structured) and volcengine inherit it immediately.
- The missing `dashscope` table entry is added (its absence is why that URL was pasted at three call sites; `health_check()` also couldn't see the provider). The cached dashscope clients and `_get_qwen_client` now build from the table.
- The bare OpenAI constructor passes `base_url` explicitly: the SDK only reads the **env var**, so a YAML-only `OPENAI_BASE_URL` was silently ignored.
- `get_async_openrouter_client` is replaced by a generic `get_async_ai_client(provider)`; the dead `base_url` field in the qwen vision entry is deleted.
- **New: `<PROVIDER>_MODEL`** picks the chat/structured model per provider, mirroring the existing `<PROVIDER>_VISION_MODEL` — without it a redirect is half-usable, because openrouter's default model id 404s on most self-hosted endpoints.
- `config.yaml` documents the mechanism with a DashScope example; CHANGELOG updated.

## Evidence

- New public gate `test_base_url_override_reaches_the_file_extraction_clients` pins all four construction paths to the override **and** to the official-gateway fallback when unset (sibling of the existing `get_llm` pin).
- Local behaviour suite (fake OpenAI-compatible gateway, gitignored `tests/`): `unified_file_extract` and `async_get_structured_output` traffic actually arrives at the configured endpoint with the configured model and auth header.
- Full battery green: 276 passed (`mirobody/`), `lint-imports` 3 contracts kept, bundle/index `--check` OK.
- End-to-end on the local stack with `OPENROUTER_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1`, `OPENROUTER_VISION_MODEL=qwen3-vl-flash`, `OPENROUTER_MODEL=qwen-flash`, and a DashScope key as `OPENROUTER_API_KEY` (a key that openrouter.ai would 401): real report photo upload → vision OCR → structured extraction → **19 indicators** written and shown in the UI with the report's true date, zero provider fallbacks; agent chat answered from the data via `query_health_indicators`.

Note for reviewers: pointing provider A's base_url at provider B's *official* endpoint additionally requires B to tolerate A's request dialect (e.g. OpenRouter's `reasoning` extra_body — DashScope tolerates it; gateways like LiteLLM/one-api do too). That caveat is documented next to the config keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)