### PR TITLE
llm: finish the #52 residue — Doubao off its vendor SDK, provider tables collapsed, embedding model configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,54 @@
   DashScope, OpenAI, Volcengine) now honor their `<PROVIDER>_BASE_URL`;
   `OPENAI_BASE_URL` also works from config, not just the environment.
 
+- **The Doubao/Volcengine tier had never run.** It was the one provider built
+  on a vendor SDK (`volcengine-python-sdk[ark]`), which is declared in `[app]`
+  but is not a base dependency, so vision extraction, structured output and
+  text completion all raised `ModuleNotFoundError` before building a request.
+  Ark's `/api/v3` is an OpenAI-compatible endpoint and nothing here used an
+  Ark-only feature, so all three now go through the same `AsyncOpenAI` client
+  as every other provider — which also means `VOLCENGINE_BASE_URL` and
+  `VOLCENGINE_MODEL` reach them (Ark serves its Coding and Agent plans from
+  `/api/coding/v3` and `/api/plan/v3`).
+
+- **An `ANTHROPIC_API_KEY`-only deployment got silence from the utility LLM
+  helpers.** `claude` sat third in the auto-selection order, but
+  `async_get_text_completion`'s claude arm logged "not supported yet" and
+  returned `None` without trying the next available provider, and
+  `async_get_structured_output` has no claude arm at all. It is out of the
+  auto-selection list, so such a deployment falls through to a provider that
+  answers. (Agent chat was never affected — it reaches Claude through
+  `PROVIDERS_DEEP`.)
+
 ### Added
 
 - **`<PROVIDER>_MODEL`** picks the chat/structured-extraction model per
   provider, mirroring the existing `<PROVIDER>_VISION_MODEL` — needed when a
   redirected endpoint does not serve the provider's default model id.
+
+- **`<PROVIDER>_EMBEDDING_MODEL`** picks the embedding model per provider, the
+  last table of model ids config could not reach: a deployment pointing
+  `OPENROUTER_BASE_URL` at its own vLLM/TEI serving could not tell mirobody
+  what that serving calls the model, and embeddings 404'd.
+  `scripts/build_loinc_embeddings.py` reads the same key (and
+  `<PROVIDER>_BASE_URL`), so a rebuilt matrix and the queries against it agree
+  by construction — and a mismatch still fails loudly rather than ranking in
+  the wrong vector space.
+
+### Removed
+
+- **`volcengine-python-sdk[ark]` is no longer a dependency** of `[app]`. It
+  ships every Volcengine product API: 138 `volcenginesdk*` packages, **245 MB
+  installed** (measured in a clean venv, 2026-09-02) to make one
+  chat/completions call that `openai` already makes.
+
+- Dead LLM-config surface that existed only to hold stale model ids and URLs:
+  `get_openai_chat` (rejected every model outside a hardcoded
+  `["gpt-4o", "gpt-4.1"]` allowlist, zero callers), `AIConfig`'s second
+  base_url table (`AI_PROVIDER`), its unread `api_path`/`type`/`model` fields
+  and unreachable entries, nine unused classmethods, and the sync half of
+  `AIClientManager` (every accessor had zero callers; `get_client`'s mapping
+  keyed model names like `gpt-4o` onto the OpenAI client).
 
 ## 1.3.0
 

--- a/config.yaml
+++ b/config.yaml
@@ -283,8 +283,10 @@ OPENROUTER_API_KEY: ""
 # endpoint with `<PROVIDER>_BASE_URL` (OPENROUTER_BASE_URL, DASHSCOPE_BASE_URL,
 # OPENAI_BASE_URL, …) — chat, vision/file parsing, structured extraction and
 # embeddings all follow it. If the endpoint does not serve the default model
-# ids, pick the models with `<PROVIDER>_MODEL` (chat/structured extraction)
-# and `<PROVIDER>_VISION_MODEL` (image/PDF parsing). Example — everything
+# ids, pick the models with `<PROVIDER>_MODEL` (chat/structured extraction),
+# `<PROVIDER>_VISION_MODEL` (image/PDF parsing) and `<PROVIDER>_EMBEDDING_MODEL`
+# (embeddings — see the EMBEDDING_PROVIDER block below, changing it means
+# re-embedding). Example — everything
 # through DashScope while keeping the OpenRouter-style one-key setup:
 #   OPENROUTER_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
 #   OPENROUTER_MODEL: qwen-flash
@@ -522,9 +524,14 @@ ENABLE_INDICATOR_EXTRACTION: 1
 #               OPENROUTER_BASE_URL to it (any `<PROVIDER>_BASE_URL` key
 #               redirects its OpenAI-compatible provider) — corpus and queries
 #               stay in one
-#               vector space as long as ONE serving does both. (OpenRouter
-#               serves the 8B and 4B sizes; 0.6B returned 404 "No endpoints
-#               found" when checked on 2026-08-23.)
+#               vector space as long as ONE serving does both. If that serving
+#               publishes the model under a different id, name it with
+#               OPENROUTER_EMBEDDING_MODEL (`<PROVIDER>_EMBEDDING_MODEL`);
+#               scripts/build_loinc_embeddings.py reads the same two keys, so
+#               the matrix it builds and the queries agree by construction —
+#               and disagree LOUDLY if you change one without rebuilding.
+#               (OpenRouter serves the 8B and 4B sizes; 0.6B returned 404 "No
+#               endpoints found" when checked on 2026-08-23.)
 #   qwen        DASHSCOPE_API_KEY   text-embedding-v4 (the productized
 #               Qwen3-Embedding; batch cap 10, dimensions: 1024), columns
 #               embedding_qwen3 / embedding_qwen. The DashScope fallback path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -469,14 +469,16 @@ survive whichever option is picked.
 
 `utils/config/llm.py` (`LLMConfig`) and `utils/llm/config.py` (`AIConfig`) both
 answer "which provider, what base_url, what key", and both end up constructing
-an `AsyncOpenAI`. They overlap on openai / openrouter / dashscope / volcengine /
-gemini. The near-identical import paths make them easy to confuse, which is why
+an `AsyncOpenAI`. They overlap on openai / openrouter / dashscope /
+volcengine. The near-identical import paths make them easy to confuse, which is why
 both now carry docstrings pointing at each other.
 
 Merging is a behaviour change, not a tidy-up:
 
 * different provider sets — `LLMConfig` covers 11 (incl. deepseek, zhipu,
-  moonshot, anthropic, vertex_ai, azure), `AIConfig` covers 6;
+  moonshot, anthropic, vertex_ai, azure), `AIConfig` covers 4 (the
+  OpenAI-compatible ones: openai, openrouter, dashscope, volcengine) plus
+  gemini in its auto-selection order;
 * different construction paths — `LLMConfig` is YAML-driven through
   `global_config().get_llm()`; `AIConfig` pairs with `clients.py`'s
   `client_manager` and a hardcoded table;

--- a/mirobody/test_one_key_defaults.py
+++ b/mirobody/test_one_key_defaults.py
@@ -162,6 +162,7 @@ def test_base_url_override_reaches_the_file_extraction_clients(monkeypatch):
     from mirobody.utils.config.config import Config
     from mirobody.utils.llm.clients import AIClientManager
     from mirobody.utils.llm.file_processors.backends_openai import (
+        _get_doubao_client,
         _get_openrouter_client,
         _get_qwen_client,
     )
@@ -170,10 +171,12 @@ def test_base_url_override_reaches_the_file_extraction_clients(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
     monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-ds-test")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-oa-test")
+    monkeypatch.setenv("VOLCENGINE_API_KEY", "sk-ve-test")
     for env, url in (
         ("OPENROUTER_BASE_URL", "http://gateway.internal:8000/v1"),
         ("DASHSCOPE_BASE_URL",  "http://gateway.internal:8001/v1"),
         ("OPENAI_BASE_URL",     "http://gateway.internal:8002/v1"),
+        ("VOLCENGINE_BASE_URL", "http://gateway.internal:8003/v1"),
     ):
         monkeypatch.setenv(env, url)
     Config(yaml_filenames=str(_CONFIG))
@@ -189,11 +192,17 @@ def test_base_url_override_reaches_the_file_extraction_clients(monkeypatch):
     assert base(manager.get_async_dashscope_client()) == "http://gateway.internal:8001/v1"
     assert base(manager.get_async_openai_client()) == "http://gateway.internal:8002/v1", \
         "OPENAI_BASE_URL must work from config too, not only as the SDK env var"
+    # Doubao/Ark is in this list because it is no longer a vendor-SDK special
+    # case: Ark's own Coding and Agent plans live at /api/coding/v3 and
+    # /api/plan/v3, so its URL is a deployment question like everyone else's.
+    assert base(_get_doubao_client()) == "http://gateway.internal:8003/v1"
 
-    for env in ("OPENROUTER_BASE_URL", "DASHSCOPE_BASE_URL", "OPENAI_BASE_URL"):
+    for env in ("OPENROUTER_BASE_URL", "DASHSCOPE_BASE_URL", "OPENAI_BASE_URL",
+                "VOLCENGINE_BASE_URL"):
         monkeypatch.delenv(env)
     manager = AIClientManager()
     assert base(_get_openrouter_client()) == "https://openrouter.ai/api/v1"
     assert base(_get_qwen_client()) == "https://dashscope.aliyuncs.com/compatible-mode/v1"
-    assert base(manager.get_async_openai_client()) == "https://api.openai.com/v1", \
+    assert base(manager.get_async_openai_client()) == "https://api.openai.com/v1"
+    assert base(_get_doubao_client()) == "https://ark.cn-beijing.volces.com/api/v3", \
         "unset override must fall back to each provider's own gateway"

--- a/mirobody/utils/embedding.py
+++ b/mirobody/utils/embedding.py
@@ -141,6 +141,29 @@ EMBEDDING_MODEL_IDS: dict[str, str] = {
     "openrouter": "qwen/qwen3-embedding-8b",
 }
 
+#: `<PROVIDER>_EMBEDDING_MODEL` overrides the default above, the way
+#: `<PROVIDER>_MODEL` and `<PROVIDER>_VISION_MODEL` do on the chat and vision
+#: paths. It exists for the same reason (issue #52): a deployment that points
+#: `OPENROUTER_BASE_URL` at its own vLLM/TEI serving cannot be expected to
+#: serve `qwen/qwen3-embedding-8b` under that exact id, and before this the
+#: default was unreachable from config — embeddings 404'd with no way out but
+#: switching provider.
+#:
+#: It reaches BOTH sides of the vector space at once: the factories below build
+#: the request from this function, and `indicator/semantic.py` stamps and checks
+#: matrix identity through it, so an override on a matrix built with the old
+#: model fails loudly ("built by X, queries embedded by Y") instead of returning
+#: confident nonsense. Changing it means re-embedding, exactly like changing
+#: EMBEDDING_PROVIDER.
+#:
+#: The 1024 `dimensions` in the factories is deliberately NOT config: it is the
+#: width of the database columns, a schema fact rather than a deployment one.
+def embedding_model_override(provider: str) -> str:
+    """`<PROVIDER>_EMBEDDING_MODEL` for this provider, or "" when unset."""
+    from .config import safe_read_cfg
+
+    return (safe_read_cfg(f"{provider.upper()}_EMBEDDING_MODEL", "") or "").strip()
+
 
 def resolve_embedding_provider() -> str:
     """`EMBEDDING_PROVIDER` if set; otherwise pick by which API key exists.
@@ -171,7 +194,7 @@ def embedding_model_id(provider: str | None = None) -> str:
     """The model id the given (or configured) provider embeds with."""
     if provider is None:
         provider = resolve_embedding_provider()
-    return EMBEDDING_MODEL_IDS.get(provider, "")
+    return embedding_model_override(provider) or EMBEDDING_MODEL_IDS.get(provider, "")
 
 
 def _emb_provider(name: str):
@@ -189,7 +212,7 @@ def _gemini():
 
     use_vertex = os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "0").lower() in ("true", "1")
     llm = global_config().get_llm(LLMProvider.VERTEX_AI if use_vertex else LLMProvider.GEMINI)
-    model = EMBEDDING_MODEL_IDS["gemini"]
+    model = embedding_model_id("gemini")
 
     if use_vertex:
         # Vertex :predict accepts one input per request for this model;
@@ -231,7 +254,7 @@ def _qwen():
         "embeddings",
         10,  # DashScope caps a text-embedding-v4 request at 10 inputs
         1,  # max_concurrency
-        lambda chunk: {"model": EMBEDDING_MODEL_IDS["qwen"], "input": chunk, "dimensions": 1024},
+        lambda chunk: {"model": embedding_model_id("qwen"), "input": chunk, "dimensions": 1024},
         lambda data: [item["embedding"] for item in data["data"]],
     )
 
@@ -268,7 +291,7 @@ def _openrouter():
         256,
         4,  # max_concurrency
         lambda chunk: {
-            "model": EMBEDDING_MODEL_IDS["openrouter"],
+            "model": embedding_model_id("openrouter"),
             "input": chunk,
             "dimensions": 1024,
         },

--- a/mirobody/utils/llm/__init__.py
+++ b/mirobody/utils/llm/__init__.py
@@ -15,7 +15,7 @@ streaming/agentic client stack with MCP tool calling.
 from .clients import client_manager
 
 # Configuration management
-from .config import AI_CONFIG, AIConfig
+from .config import AIConfig
 
 from .file_processors import (
     FileProcessor,
@@ -45,7 +45,6 @@ __author__ = "AI Team"
 __all__ = [
     # === Configuration and management ===
     "AIConfig",  # Configuration manager
-    "AI_CONFIG",  # Global config object
     "client_manager",  # Client manager
     # === File processing ===
     "FileProcessor",  # File processor

--- a/mirobody/utils/llm/__init__.py
+++ b/mirobody/utils/llm/__init__.py
@@ -30,7 +30,6 @@ from .utils import (
     async_get_doubao_structured_output,
     async_get_structured_output,
     async_get_text_completion,
-    get_openai_chat,
 )
 
 # LLM provider config
@@ -55,7 +54,6 @@ __all__ = [
     "doubao_file_extract",  # Doubao file extraction
     "unified_file_extract",  # 🔥 Unified file extraction entry (auto-select model)
     # === Utility functions ===
-    "get_openai_chat",  # Get OpenAI chat
     "async_get_doubao_structured_output",  # Get Doubao structured output
     "async_get_structured_output",  # 🔥 Unified structured output (auto-select provider)
     "async_get_text_completion",  # 🔥 Unified text generation (auto-select provider)

--- a/mirobody/utils/llm/clients.py
+++ b/mirobody/utils/llm/clients.py
@@ -26,18 +26,21 @@ class AIClientManager:
         
         dashscope_config = AIConfig.get_provider_config("dashscope")
         if dashscope_config["api_key"]:
-            self._clients["dashscope"] = OpenAI(api_key=dashscope_config["api_key"], base_url=dashscope_config["api_base"])
-            self._async_clients["dashscope"] = AsyncOpenAI(api_key=dashscope_config["api_key"], base_url=dashscope_config["api_base"])
+            self._async_clients["dashscope"] = AsyncOpenAI(
+                api_key=dashscope_config["api_key"], base_url=dashscope_config["api_base"]
+            )
 
-        # OpenAI client. base_url passed explicitly: the bare constructor reads
-        # only the OPENAI_BASE_URL *environment variable*, so an override set in
-        # config.yaml alone was silently ignored while every other provider's
-        # `<PROVIDER>_BASE_URL` worked. `or None` keeps the SDK default when unset.
-        openai_api_key = safe_read_cfg("OPENAI_API_KEY")
-        if openai_api_key:
-            openai_base_url = safe_read_cfg("OPENAI_BASE_URL") or None
-            self._clients["openai"] = OpenAI(api_key=openai_api_key, base_url=openai_base_url)
-            self._async_clients["openai"] = AsyncOpenAI(api_key=openai_api_key, base_url=openai_base_url)
+        # OpenAI client, through the same table as everyone else. It used to
+        # read the two keys itself, which had a bug of its own — the bare
+        # constructor honours only the OPENAI_BASE_URL *environment variable*,
+        # so an override set in config.yaml alone was silently ignored — and,
+        # more to the point, a second place where a provider's endpoint was
+        # decided is exactly how #52 came about.
+        openai_config = AIConfig.get_provider_config("openai")
+        if openai_config["api_key"]:
+            self._async_clients["openai"] = AsyncOpenAI(
+                api_key=openai_config["api_key"], base_url=openai_config["api_base"]
+            )
 
         # Google Gemini client — lock to AI Studio backend; without vertexai=False,
         # GOOGLE_GENAI_USE_VERTEXAI=true in env reroutes requests to aiplatform with
@@ -45,7 +48,6 @@ class AIClientManager:
         google_api_key = safe_read_cfg("GOOGLE_API_KEY")
         if google_api_key:
             try:
-                self._clients["gemini"] = genai.Client(api_key=google_api_key, vertexai=False)
                 self._async_clients["gemini"] = genai.Client(api_key=google_api_key, vertexai=False).aio
             except Exception as e:
                 import logging
@@ -53,42 +55,14 @@ class AIClientManager:
 
         self._initialized = True
 
-    def get_client(self, provider: str) -> Any:
-        """Get synchronous client"""
-        self._initialize_clients()
-
-        # For volcengine/doubao, use dynamically created OpenAI-compatible client
-        if provider in ["volcengine", "doubao-lite"]:
-            return self.get_ai_client(provider)
-
-        client_mapping = {
-            "openai": "openai",
-            "gpt-4o": "openai",
-            "gpt-4.1": "openai",
-            "gpt-o3": "openai",
-            "gpt4o-mini": "openai",
-            "gemini": "gemini",
-            "dashscope": "dashscope", # similar to openai but use different url
-        }
-
-        client_key = client_mapping.get(provider)
-        if not client_key or client_key not in self._clients:
-            raise ValueError(f"Unsupported client: {provider}")
-
-        return self._clients[client_key]
-
     def get_async_client(self, provider: str) -> Any:
         """Get asynchronous client"""
         self._initialize_clients()
 
         client_mapping = {
             "openai": "openai",
-            "gpt-4o": "openai",
-            "gpt-4.1": "openai",
-            "gpt-o3": "openai",
-            "gpt4o-mini": "openai",
             "gemini": "gemini",
-            "dashscope": "dashscope", # similar to openai but use different url
+            "dashscope": "dashscope",  # similar to openai but a different url
         }
 
         client_key = client_mapping.get(provider)
@@ -98,7 +72,13 @@ class AIClientManager:
         return self._async_clients[client_key]
 
     def get_ai_client(self, provider: str) -> OpenAI:
-        """Create AI client for specified provider (OpenAI-compatible)"""
+        """Create AI client for specified provider (OpenAI-compatible).
+
+        No caller today — every LLM path in the repo is async. Kept because it
+        is the sync entry point a future call site must use: the alternative it
+        replaces is `OpenAI(base_url="https://...")` written inline, which is
+        precisely how #52's hardcoded openrouter.ai got there.
+        """
         config = AIConfig.get_provider_config(provider)
 
         return OpenAI(api_key=config["api_key"], base_url=config["api_base"])
@@ -109,17 +89,9 @@ class AIClientManager:
 
         return AsyncOpenAI(api_key=config["api_key"], base_url=config["api_base"])
 
-    def get_openai_client(self) -> OpenAI:
-        """Get OpenAI client"""
-        return self.get_client("openai")
-
     def get_async_openai_client(self) -> AsyncOpenAI:
         """Get async OpenAI client"""
         return self.get_async_client("openai")
-    
-    def get_dashscope_client(self) -> OpenAI:
-        """Get DashScope client"""
-        return self.get_client("dashscope")
     
     def get_async_dashscope_client(self) -> AsyncOpenAI:
         """Get async DashScope client"""
@@ -128,12 +100,6 @@ class AIClientManager:
     @staticmethod
     def _use_vertex() -> bool:
         return os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "0").lower() in ("true", "1")
-
-    def get_gemini_client(self) -> genai.Client:
-        """Get Gemini client (auto-routes to Vertex when GOOGLE_GENAI_USE_VERTEXAI=true)."""
-        if self._use_vertex():
-            return self.get_vertex_gemini_client()
-        return self.get_client("gemini")
 
     def get_async_gemini_client(self):
         """Get async Gemini client (auto-routes to Vertex when GOOGLE_GENAI_USE_VERTEXAI=true)."""
@@ -167,30 +133,6 @@ class AIClientManager:
             self._async_clients["vertex_gemini"] = client.aio
         return self._async_clients["vertex_gemini"]
 
-    def is_client_available(self, provider: str) -> bool:
-        """Whether an async client for `provider` was successfully constructed."""
-        self._initialize_clients()
-        client_mapping = {
-            "openai": "openai",
-            "gemini": "gemini",
-            "dashscope": "dashscope",
-        }
-        client_key = client_mapping.get(provider)
-        return bool(client_key and client_key in self._async_clients)
-
-    def health_check(self) -> Dict[str, bool]:
-        """Check health status of all clients"""
-        health_status = {}
-
-        for provider in AIConfig.get_all_providers():
-            try:
-                config = AIConfig.get_provider_config(provider)
-                health_status[provider] = bool(config.get("api_key"))
-            except Exception:
-                health_status[provider] = False
-
-        return health_status
-
 
 # The one client entry point. Everything below it used to be a second,
 # never-wired one: a `_GlobalClients` lazy holder (whose `client_manager`
@@ -202,4 +144,12 @@ class AIClientManager:
 # `__all__` regardless: a documented public name whose value was permanently
 # None. A module-level `get_ai_client()` wrapper went the same way; the
 # METHOD of the same name on AIClientManager is live and stays.
+#
+# The class shrank the same way: every SYNC accessor (`get_client`,
+# `get_openai_client`, `get_dashscope_client`, `get_gemini_client`) had zero
+# callers — the whole repo's LLM traffic is async — as did `is_client_available`
+# and `health_check`, and `get_client`'s mapping keyed MODEL names ("gpt-4o",
+# "gpt-4.1") onto the openai client, so it carried stale model ids in code for
+# no one. Only `get_ai_client` stays sync, as the entry point a future sync
+# call site must use instead of constructing its own client.
 client_manager = AIClientManager()

--- a/mirobody/utils/llm/config.py
+++ b/mirobody/utils/llm/config.py
@@ -1,16 +1,23 @@
 """Provider catalogue for the `utils/llm/` package.
 
-A hardcoded table of base_urls, default models and the priority order used to
-auto-select a provider from whichever API keys are present.
+Two tables, with two distinct jobs and no overlap:
+
+* `_CONFIG` — the OpenAI-compatible providers and where they live. It answers
+  "which key, which endpoint" for `clients.py`, and `get_provider_config` is
+  the ONE place `<PROVIDER>_BASE_URL` is applied. Gemini is absent on purpose:
+  it is reached through the google-genai SDK, not a base_url.
+* `_DEFAULT_PROVIDER_PRIORITY` — auto-selection order and the fallback default
+  model per provider, for callers that were handed no model name.
+
+A URL or model id may appear in these tables and nowhere else. A call site that
+builds an SDK client with its own literal is how issue #52 happened: vision
+extraction hardcoded openrouter.ai, so a deployment that redirected OpenRouter
+with OPENROUTER_BASE_URL got its text requests proxied and its image requests
+401'd against the public gateway.
 
 NOT the same thing as `mirobody/utils/config/llm.py`, despite the near-identical
 path — that one is `LLMConfig`, the YAML-driven member of the `Config` family.
 See its docstring for the full comparison and why the two have not been merged.
-
-AI model configuration management module
-
-Manages AI model configurations, provides validation and retrieval interfaces,
-supports dynamic configuration loading, and auto-selects providers based on available API keys.
 """
 
 import os
@@ -26,18 +33,6 @@ def _vertex_ai_enabled() -> bool:
 class AIConfig:
     """AI model configuration manager"""
 
-    _PROVIDER = {
-        "openai": {
-            "base_url": "https://api.openai.com/v1",
-        },
-        "volcengine": {
-            "base_url": "https://ark.cn-beijing.volces.com/api/v3",
-        },
-        "dashscope": {
-            "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        },
-    }
-
     # Used for auto-selecting available providers
     _DEFAULT_PROVIDER_PRIORITY: List[Dict[str, Any]] = [
         {
@@ -51,12 +46,6 @@ class AIConfig:
             "api_key_env": "OPENROUTER_API_KEY",
             "default_model": "google/gemini-3-flash-preview",
             "description": "OpenRouter (Multi-model Gateway)",
-        },
-        {
-            "name": "claude",
-            "api_key_env": "ANTHROPIC_API_KEY",
-            "default_model": "claude-3-7-sonnet-20250219",
-            "description": "Anthropic Claude",
         },
         {
             "name": "gemini",
@@ -80,85 +69,34 @@ class AIConfig:
             "description": "Aliyun DashScope (Qwen Flash)",
         },
     ]
+    # `claude` used to sit third in this list, and an ANTHROPIC_API_KEY-only
+    # deployment therefore auto-selected it — into a dead end: the claude arm of
+    # async_get_text_completion logged "not supported yet" and returned None
+    # WITHOUT trying the next available provider, and async_get_structured_output
+    # has no claude arm at all. Removing it is what makes such a deployment fall
+    # through to a provider that answers. Chat is unaffected: the agent reaches
+    # Claude through config.yaml's PROVIDERS_DEEP, not this table.
 
-    # AI provider configurations
-    _CONFIG = {
-        "gpt4o-mini": {
-            "model": "gpt-4o-mini",
-            "api_key_env": "OPENAI_API_KEY",
-            "api_base": "https://api.openai.com",
-            "api_path": "/v1/chat/completions",
-            "type": "openai",
-        },
-        "gpt-4o": {
-            "model": "gpt-4o",
-            "api_key_env": "OPENAI_API_KEY",
-            "api_base": "https://api.openai.com",
-            "api_path": "/v1/chat/completions",
-            "type": "openai",
-        },
-        "gpt-5.2": {
-            "model": "gpt-5.2",
-            "api_key_env": "OPENAI_API_KEY",
-            "api_base": "https://api.openai.com",
-            "api_path": "/v1/chat/completions",
-            "type": "openai",
-        },
-        "gpt-o3": {
-            "model": "o3",
-            "api_key_env": "OPENAI_API_KEY",
-            "api_base": "https://api.openai.com",
-            "api_path": "/v1/chat/completions",
-            "type": "openai",
-        },
-        "volcengine": {
-            "model": "doubao-seed-1-8-251228",
-            "api_key_env": "VOLCENGINE_API_KEY",
-            "api_base": "https://ark.cn-beijing.volces.com/api/v3",
-            "api_path": "/chat/completions",
-            "type": "volcengine",
-        },
-        "doubao-lite": {
-            "model": "doubao-1-5-lite-32k-250115",
-            "api_key_env": "VOLCENGINE_API_KEY",
-            "api_base": "https://ark.cn-beijing.volces.com/api/v3",
-            "api_path": "/chat/completions",
-            "type": "volcengine",
-        },
-        "claude": {
-            "model": "claude-3-7-sonnet-20250219",
-            "api_key_env": "ANTHROPIC_API_KEY",
-            "api_base": "https://api.anthropic.com",
-            "api_path": "/v1/messages",
-            "type": "claude",
-        },
-        "gemini": {
-            "model": "gemini-3-flash-preview",
-            "api_key_env": "GOOGLE_API_KEY",
-            "api_base": "https://generativelanguage.googleapis.com",
-            "api_path": "/v1/chat/completions",
-            "type": "gemini",
-        },
+    # Where each OpenAI-compatible provider lives, when nothing overrides it.
+    _CONFIG: Dict[str, Dict[str, str]] = {
         "openai": {
-            "model": "gpt-4o-mini",
             "api_key_env": "OPENAI_API_KEY",
-            "api_base": "https://api.openai.com",
-            "api_path": "/v1/chat/completions",
-            "type": "openai",
+            "api_base": "https://api.openai.com/v1",
         },
         "openrouter": {
-            "model": "google/gemini-3-flash-preview",
             "api_key_env": "OPENROUTER_API_KEY",
             "api_base": "https://openrouter.ai/api/v1",
-            "api_path": "/chat/completions",
-            "type": "openai",
         },
         "dashscope": {
-            "model": "qwen-flash",
             "api_key_env": "DASHSCOPE_API_KEY",
             "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-            "api_path": "/chat/completions",
-            "type": "openai",
+        },
+        # Ark speaks chat/completions; its Coding and Agent plans are served
+        # from /api/coding/v3 and /api/plan/v3, which is why the URL below is a
+        # default and not a constant.
+        "volcengine": {
+            "api_key_env": "VOLCENGINE_API_KEY",
+            "api_base": "https://ark.cn-beijing.volces.com/api/v3",
         },
     }
 
@@ -183,36 +121,6 @@ class AIConfig:
         )
         return config
 
-    @classmethod
-    def get_all_providers(cls) -> list:
-        """Get list of all supported providers"""
-        return list(cls._CONFIG.keys())
-
-    @classmethod
-    def get_providers_by_type(cls, provider_type: str) -> list:
-        """Get provider list by type"""
-        return [provider for provider, config in cls._CONFIG.items() if config.get("type") == provider_type]
-
-    @classmethod
-    def validate_provider(cls, provider: str) -> bool:
-        """Validate if provider is supported"""
-        return provider in cls._CONFIG
-
-    @classmethod
-    def add_provider(cls, provider: str, config: Dict[str, Any]) -> None:
-        """Dynamically add new provider configuration"""
-        required_fields = ["model", "api_key_env", "api_base", "api_path", "type"]
-        for field in required_fields:
-            if field not in config:
-                raise ValueError(f"Configuration missing required field: {field}")
-
-        cls._CONFIG[provider] = config
-
-    @classmethod
-    def get_config_summary(cls) -> Dict[str, str]:
-        """Get configuration summary"""
-        return {provider: f"{config['type']} - {config['model']}" for provider, config in cls._CONFIG.items()}
-
     # ========== Auto-select provider methods ==========
 
     @staticmethod
@@ -226,9 +134,9 @@ class AIConfig:
     def get_available_provider(cls) -> Optional[Dict[str, Any]]:
         """
         Get first available provider (based on configured API keys)
-        
+
         Priority: openai > openrouter > gemini > volcengine > dashscope
-        
+
         Returns:
             Provider config dict with name, api_key_env, default_model, description
             Returns None if no provider is available
@@ -240,24 +148,13 @@ class AIConfig:
         return None
 
     @classmethod
-    def get_available_provider_name(cls) -> Optional[str]:
-        """
-        Get first available provider name
-        
-        Returns:
-            Provider name, or None if no provider is available
-        """
-        provider = cls.get_available_provider()
-        return provider["name"] if provider else None
-    
-    @classmethod
     def get_provider_by_priority_name(cls, name: str) -> Optional[Dict[str, Any]]:
         """
         Get provider config by name from priority list
-        
+
         Args:
             name: Provider name (openai/openrouter/gemini/volcengine/dashscope)
-            
+
         Returns:
             Provider config dict
         """
@@ -265,27 +162,12 @@ class AIConfig:
             if provider["name"] == name:
                 return cls._resolve_provider(provider)
         return None
-    
-    @classmethod
-    def list_available_providers(cls) -> List[str]:
-        """
-        List all available providers with configured API keys
-        
-        Returns:
-            List of available provider names
-        """
-        available = []
-        for provider in cls._DEFAULT_PROVIDER_PRIORITY:
-            api_key = safe_read_cfg(provider["api_key_env"])
-            if api_key:
-                available.append(provider["name"])
-        return available
-    
+
     @classmethod
     def get_provider_status(cls) -> Dict[str, bool]:
         """
         Get configuration status of all providers
-        
+
         Returns:
             Mapping of provider names to availability status
         """
@@ -293,60 +175,3 @@ class AIConfig:
             provider["name"]: bool(safe_read_cfg(provider["api_key_env"]))
             for provider in cls._DEFAULT_PROVIDER_PRIORITY
         }
-    
-    @classmethod
-    def get_default_model_for_available_provider(cls) -> Optional[str]:
-        """
-        Get default model for available provider
-        
-        Returns:
-            Default model name, or None if no provider is available
-        """
-        provider = cls.get_available_provider()
-        return provider["default_model"] if provider else None
-    
-    @classmethod
-    def auto_get_provider_config(cls, preferred_provider: Optional[str] = None) -> Dict[str, Any]:
-        """
-        Auto-get provider config with optional preferred provider
-        
-        If preferred_provider is specified and its API key is configured, use it;
-        otherwise auto-select first available provider.
-        
-        Args:
-            preferred_provider: Preferred provider name (optional)
-            
-        Returns:
-            Provider config dict
-            
-        Raises:
-            ValueError: If no provider is available
-        """
-        if preferred_provider:
-            if preferred_provider in cls._CONFIG:
-                config = cls._CONFIG[preferred_provider]
-                api_key = safe_read_cfg(config["api_key_env"])
-                if api_key:
-                    return cls.get_provider_config(preferred_provider)
-                # Preferred provider unavailable, continue auto-selection
-        
-        available_provider = cls.get_available_provider()
-        if not available_provider:
-            status = cls.get_provider_status()
-            raise ValueError(
-                f"No AI provider available. Please configure one of the following API keys:\n"
-                f"  - OPENAI_API_KEY (for OpenAI)\n"
-                f"  - OPENROUTER_API_KEY (for OpenRouter)\n"
-                f"  - ANTHROPIC_API_KEY (for Claude)\n"
-                f"  - GOOGLE_API_KEY (for Gemini)\n"
-                f"  - VOLCENGINE_API_KEY (for Doubao)\n"
-                f"  - DASHSCOPE_API_KEY (for DashScope/Qwen)\n"
-                f"Current status: {status}"
-            )
-        
-        return cls.get_provider_config(available_provider["name"])
-
-
-# Global configuration objects
-AI_CONFIG = AIConfig._CONFIG
-AI_PROVIDER = AIConfig._PROVIDER

--- a/mirobody/utils/llm/file_processors/backends_openai.py
+++ b/mirobody/utils/llm/file_processors/backends_openai.py
@@ -5,6 +5,14 @@ implementation and differ only in client construction and a per-provider
 `extra_body` that turns "thinking" off (it costs latency and buys nothing for
 extraction). Gemini is NOT here: it has its own SDK and its own PDF handling,
 in `gemini.py`.
+
+Doubao used to be the exception, reached through volcengine-python-sdk's
+AsyncArk. It never needed to be: Ark's /api/v3 is an OpenAI-compatible
+endpoint (this repo's own sync volcengine client had always been a bare
+`OpenAI` pointed at it), the SDK was declared in the `[app]` extra but not
+installed in dev, and nothing here used a single Ark-only feature — so the
+whole tier raised ModuleNotFoundError on a normal install and no test could
+reach it.
 """
 
 from __future__ import annotations
@@ -14,14 +22,10 @@ import json
 import logging
 import pathlib
 import time
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional
 
 from openai import AsyncOpenAI
 
-if TYPE_CHECKING:
-    from volcenginesdkarkruntime import AsyncArk
-
-from ..config import AIConfig
 from .media import (
     _build_vision_message,
     _convert_pdf_to_base64_images,
@@ -34,7 +38,10 @@ from ...file_types import IMAGE_EXTENSIONS
 PROVIDER_EXTRA_PARAMS: Dict[str, Dict[str, Any]] = {
     "openrouter": {"extra_body": {"reasoning": {"enabled": False}}},
     "qwen": {"extra_body": {"enable_thinking": False}},
-    "doubao": {"thinking": {"type": "disabled"}},
+    # extra_body, not a top-level kwarg: these are spread into
+    # `chat.completions.create(**api_params)`, and the OpenAI SDK rejects
+    # parameters it does not declare. AsyncArk tolerated `thinking=` there.
+    "doubao": {"extra_body": {"thinking": {"type": "disabled"}}},
 }
 
 # =============================================================================
@@ -42,7 +49,7 @@ PROVIDER_EXTRA_PARAMS: Dict[str, Dict[str, Any]] = {
 async def _openai_compatible_process_pdf(
     pdf_path: str,
     prompt: str,
-    client: Union[AsyncOpenAI, "AsyncArk"],
+    client: AsyncOpenAI,
     model: str,
     provider: str,
     max_concurrency: int = 5,
@@ -95,7 +102,7 @@ async def _openai_compatible_process_pdf(
 async def _openai_compatible_process_image(
     image_path: str,
     prompt: str,
-    client: Union[AsyncOpenAI, "AsyncArk"],
+    client: AsyncOpenAI,
     model: str,
     provider: str,
     json_mode: bool = True
@@ -130,7 +137,7 @@ async def _openai_compatible_file_extract(
     local_file_path: str,
     prompt: str,
     model: str,
-    client: Union[AsyncOpenAI, "AsyncArk"],
+    client: AsyncOpenAI,
     provider: str,
     response_schema: Optional[Any] = None,
     json_mode: bool = True
@@ -181,11 +188,11 @@ def _get_qwen_client() -> AsyncOpenAI:
     return client_manager.get_async_ai_client("dashscope")
 
 
-def _get_doubao_client() -> "AsyncArk":
-    """Get Doubao client."""
-    from volcenginesdkarkruntime import AsyncArk
-    config = AIConfig.get_provider_config("volcengine")
-    return AsyncArk(api_key=config["api_key"], base_url=config["api_base"])
+def _get_doubao_client() -> AsyncOpenAI:
+    """Get Doubao client (Ark's /api/v3 is OpenAI-compatible)."""
+    from ..clients import client_manager
+
+    return client_manager.get_async_ai_client("volcengine")
 
 
 # =============================================================================
@@ -196,7 +203,7 @@ async def doubao_file_extract(
     local_file_path: str,
     prompt: str = "Please extract all test indicators from this report and return the result in JSON format",
     model: str = "doubao-1-5-ui-tars-250428",
-    client: Optional["AsyncArk"] = None,
+    client: Optional[AsyncOpenAI] = None,
     json_mode: bool = True
 ) -> str:
     """Doubao file extraction, supports PDF and image files."""

--- a/mirobody/utils/llm/utils.py
+++ b/mirobody/utils/llm/utils.py
@@ -50,15 +50,14 @@ async def async_get_doubao_structured_output(
     start_time = time.time()
     
     try:
-        from volcenginesdkarkruntime import AsyncArk
-        
-        # Get Doubao config
-        volcengine_config = AIConfig.get_provider_config("volcengine")
-        
-        client = AsyncArk(
-            api_key=volcengine_config["api_key"],
-            base_url=volcengine_config["api_base"],
-        )
+        # Ark's /api/v3 IS an OpenAI-compatible endpoint, so this needs no
+        # vendor SDK — and going through client_manager is what makes
+        # VOLCENGINE_BASE_URL reach it (Ark's own Coding and Agent plans are
+        # served from /api/coding/v3 and /api/plan/v3, so "the Ark URL" is
+        # already a deployment question, not a constant).
+        from .clients import client_manager
+
+        client = client_manager.get_async_ai_client("volcengine")
         
         request_params = {
             "model": model_name,
@@ -445,14 +444,15 @@ async def async_get_text_completion(
     logging.info(f"🔄 async_get_text_completion: Using {provider} provider, model: {actual_model}")
     
     try:
-        if provider in ["openai", "openrouter", "dashscope"]:
-            # OpenAI-compatible clients
+        if provider in ["openai", "openrouter", "dashscope", "volcengine"]:
+            # OpenAI-compatible clients — volcengine included: Ark's /api/v3
+            # speaks chat/completions, so it needs no vendor SDK.
             if provider == "openai":
                 client = client_manager.get_async_openai_client()
-            elif provider == "openrouter":
-                client = client_manager.get_async_ai_client("openrouter")
-            else:
+            elif provider == "dashscope":
                 client = client_manager.get_async_dashscope_client()
+            else:
+                client = client_manager.get_async_ai_client(provider)
             
             # Handle max_tokens vs max_completion_tokens for newer OpenAI models
             # Models that require max_completion_tokens: o1, o3, gpt-5.x, etc.
@@ -475,24 +475,6 @@ async def async_get_text_completion(
             content = response.choices[0].message.content
             duration = time.time() - start_time
             logging.info(f"✅ {provider} text generation completed, duration: {duration:.3f}s")
-            return content
-            
-        elif provider == "volcengine":
-            # Use Doubao
-            from volcenginesdkarkruntime import AsyncArk
-            volcengine_config = AIConfig.get_provider_config("volcengine")
-            client = AsyncArk(
-                api_key=volcengine_config["api_key"],
-                base_url=volcengine_config["api_base"],
-            )
-            response = await client.chat.completions.create(
-                model=actual_model,
-                messages=messages,
-                **kwargs
-            )
-            content = response.choices[0].message.content
-            duration = time.time() - start_time
-            logging.info(f"✅ Volcengine text generation completed, duration: {duration:.3f}s")
             return content
             
         elif provider == "gemini":

--- a/mirobody/utils/llm/utils.py
+++ b/mirobody/utils/llm/utils.py
@@ -161,7 +161,7 @@ async def async_get_structured_output(
     """
     Unified structured output function, auto-selects provider based on available API keys
     
-    Priority: openai > openrouter > claude > gemini > volcengine > dashscope
+    Priority: openai > openrouter > gemini > volcengine > dashscope
     
     Args:
         messages: Message list
@@ -386,7 +386,7 @@ async def async_get_text_completion(
     
     For generating plain text (non-JSON), such as Markdown, plain text, etc.
     
-    Priority: openai > openrouter > claude > gemini > volcengine > dashscope
+    Priority: openai > openrouter > gemini > volcengine > dashscope
     
     Args:
         messages: Message list, format: [{"role": "system/user/assistant", "content": "..."}]
@@ -511,10 +511,6 @@ async def async_get_text_completion(
                 duration = time.time() - start_time
                 logging.info(f"✅ Gemini text generation completed, duration: {duration:.3f}s")
                 return response.text
-            return None
-            
-        elif provider == "claude":
-            logging.warning("Claude text generation not supported yet, please use other providers")
             return None
             
         else:

--- a/mirobody/utils/llm/utils.py
+++ b/mirobody/utils/llm/utils.py
@@ -13,38 +13,14 @@ from .config import AIConfig
 # `PROJECT_DIR`, `os` and `uuid` used to be here to give `async_get_openai_tts`
 # somewhere to write its .mp3 — the only thing in this module that ever touched
 # the filesystem, and a function no caller ever invoked. All four went together.
+#
+# `get_openai_chat` went the same way, and was worse: it rejected every model
+# name outside a hardcoded `["gpt-4o", "gpt-4.1"]` allowlist, so the one thing
+# a caller would want it for — naming a current model — raised ValueError. Zero
+# callers, and the allowlist is the exact anti-pattern issue #52 was about: a
+# model id decided in code where no config can reach it.
 
 #-----------------------------------------------------------------------------
-
-async def get_openai_chat(model_name: str, messages: List[Dict], **kwargs) -> Optional[str]:
-    """
-    Get OpenAI chat response (compatible interface)
-
-    Args:
-        model_name: Model name
-        messages: Message list
-        **kwargs: Other parameters
-
-    Returns:
-        Response text or None
-    """
-    try:
-        if model_name not in ["gpt-4o", "gpt-4.1"]:
-            raise ValueError(f"Invalid model name: {model_name}")
-
-        from .clients import client_manager
-
-        client = client_manager.get_async_openai_client()
-
-        response = await client.chat.completions.create(model=model_name, messages=messages, **kwargs)
-
-        return response.choices[0].message.content
-
-    except Exception as e:
-        logging.error(f"OpenAI chat API error: {type(e).__name__}", stack_info=True)
-        return None
-
-
 
 async def async_get_doubao_structured_output(
     model_name: str, messages: List[Dict], response_format: Dict = None, **kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,10 +185,6 @@ app = [
     # is the same class of bug as the undeclared python-multipart / starlette /
     # anthropic before it. Named here so it stops being an accident.
     "boto3",
-    # Volcengine Ark — the one model vendor with its own SDK rather than an
-    # OpenAI-compatible endpoint (DashScope needs no SDK: it is reached through
-    # `AsyncOpenAI` pointed at its compatible-mode URL).
-    "volcengine-python-sdk[ark]>=3.0.1",
     # The official MCP SDK, for `mirobody.mcp` — which is server-side by
     # construction (`mcp/service.py` imports psycopg_pool and redis at module
     # level), so this cannot be a standalone extra and should not pretend to be.

--- a/scripts/build_loinc_embeddings.py
+++ b/scripts/build_loinc_embeddings.py
@@ -68,19 +68,23 @@ DIM = 1024
 #: costs about $0.01 per million tokens — the whole 96k-row build is under two
 #: cents. Note the endpoint is NOT in OpenRouter's /models listing, which covers
 #: chat models only; /embeddings works regardless.
-# Model ids are imported from `mirobody.utils.embedding.EMBEDDING_MODEL_IDS` in
-# main() — the same table the runtime query side reads — so this script cannot
-# drift onto a model the deployed `text_embedding()` does not call.
+# Model ids come from `mirobody.utils.embedding.embedding_model_id()` in main()
+# — the same call the runtime query side makes, so this script cannot drift onto
+# a model the deployed `text_embedding()` does not call, and it picks up a
+# `<PROVIDER>_EMBEDDING_MODEL` override on both sides at once. The endpoints
+# below are likewise defaults: `<PROVIDER>_BASE_URL` redirects them, which a
+# deployment that self-hosts the embedding model MUST be able to do — corpus
+# and queries have to come out of one serving.
 PROVIDERS: dict[str, tuple[str, str | None, int, str]] = {
     "openrouter": (
         "https://openrouter.ai/api/v1/embeddings",
-        None,                    # filled from EMBEDDING_MODEL_IDS["openrouter"]
+        None,                    # filled from embedding_model_id("openrouter")
         256,
         "OPENROUTER_API_KEY",
     ),
     "qwen": (
         "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings",
-        None,                    # filled from EMBEDDING_MODEL_IDS["qwen"]
+        None,                    # filled from embedding_model_id("qwen")
         10,                      # DashScope caps a request at 10 inputs
         "DASHSCOPE_API_KEY",
     ),
@@ -143,10 +147,9 @@ async def main() -> int:
     from mirobody.indicator.fhir.common import SYSTEM_TO_CODE, code_to_fhir_id
     from mirobody.indicator.fhir.embeddings.bundle import read_member
     from mirobody.utils import Config
-    from mirobody.utils.embedding import EMBEDDING_MODEL_IDS
+    from mirobody.utils.embedding import embedding_model_id
 
     url0, _, batch0, key0 = PROVIDERS[args.provider]
-    PROVIDERS[args.provider] = (url0, EMBEDDING_MODEL_IDS[args.provider], batch0, key0)
 
     config = await Config.init(yaml_filenames=["config.yaml", "config.local.yaml"])
     key_name = PROVIDERS[args.provider][3]
@@ -154,6 +157,13 @@ async def main() -> int:
     if not key:
         print(f"{key_name} is not set", file=sys.stderr)
         return 1
+
+    # Same two overrides the runtime honours, read AFTER Config.init so a value
+    # in config.yaml counts and not just an env var.
+    base = (config.get(key_name.replace("_API_KEY", "_BASE_URL")) or "").strip()
+    if base:
+        url0 = base.rstrip("/") + "/embeddings"
+    PROVIDERS[args.provider] = (url0, embedding_model_id(args.provider), batch0, key0)
 
     res = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "mirobody", "res")
     axis_raw = read_member("loinc_axis.csv", bundle_path=os.path.join(res, "fhir_loinc_bundle.tar.gz"))


### PR DESCRIPTION
Follow-up to #52 / #54: the residue that fix left behind, closed out under the
owner's rule that **anything naming a model or an endpoint must be overridable
from config**. Stacked on `fix-provider-base-url-override`, so this PR's base is
that branch; it retargets to `main` automatically once #54 merges.

Four commits, each independently reviewable.

### 1. Delete `get_openai_chat`

Zero callers, and it could not have had a useful one: it rejected every model
name outside a hardcoded `["gpt-4o", "gpt-4.1"]` allowlist, so asking it for a
current model raised `ValueError`. That allowlist is the anti-pattern #52 was
filed about.

### 2. Doubao through the OpenAI-compatible client; the Ark SDK is gone

The doubao/volcengine tier was the one provider built on a vendor SDK
(`volcengine-python-sdk[ark]`), declared in `[app]` and not installed in a dev
venv — so vision extraction, structured output and text completion all raised
`ModuleNotFoundError` before building a request. **The tier had never run here,
and no test could reach it.**

It never needed the SDK. Ark's `/api/v3` is an OpenAI-compatible endpoint, and
this repo's own sync volcengine client had always been a bare `OpenAI` pointed
at exactly that URL — the pyproject comment calling Ark "the one model vendor
with its own SDK rather than an OpenAI-compatible endpoint" was contradicted by
the file next to it. All three paths now go through
`client_manager.get_async_ai_client("volcengine")`, so `VOLCENGINE_BASE_URL` and
`VOLCENGINE_MODEL` reach them (Ark's Coding and Agent plans are served from
`/api/coding/v3` and `/api/plan/v3` — its URL was always a deployment question).

One behavioural difference: `thinking` moves into `extra_body`. AsyncArk took it
as a `create()` kwarg; the OpenAI SDK rejects parameters it does not declare.

What the dependency cost, measured in a clean venv on 2026-09-02: **138
`volcenginesdk*` packages, 245 MB installed** — it ships every Volcengine
product API — for one `chat/completions` call `openai` already makes.

Proof the tier is alive (this is what the handoff doc asked for): four cases
drive vision, structured output and text completion against a local
OpenAI-compatible server and assert model, `Authorization` and `thinking` inside
the body, plus a guard that nothing imports `volcenginesdkarkruntime` again. The
public gate in `test_one_key_defaults` now pins the doubao client's base_url
alongside the other three. **Not verified against real Ark** — no
`VOLCENGINE_API_KEY` on this machine.

### 3. Collapse the provider tables to what the code reads

`AIConfig` carried four kinds of unreachable literal at once:

- `_PROVIDER` / `AI_PROVIDER`, a **second** base_url table for openai,
  volcengine and dashscope with no reader anywhere — two endpoint tables is the
  precondition for the #52 class of bug;
- `_CONFIG`'s `api_path` (11 entries, no consumer), `type` (read only by a dead
  method) and `model` (nothing reads it — defaults come from the priority
  table), plus every entry no name can reach (`gpt-4o`/`gpt4o-mini`/`gpt-o3`/
  `gpt-5.2`/`doubao-lite` aliases, `gemini`, `claude`);
- openai's `api_base` was `https://api.openai.com`, missing `/v1` — harmless
  only because nothing read it;
- nine classmethods with zero callers.

What remains is the four providers `get_(async_)ai_client` builds clients for,
holding the two facts callers read. The OpenAI client is now built from
`get_provider_config` like everyone else (it read `OPENAI_API_KEY` /
`OPENAI_BASE_URL` itself — a second place deciding an endpoint), and the sync
half of `AIClientManager` goes: every sync accessor had zero callers,
`get_client`'s mapping keyed stale *model* names onto the openai client, and
`health_check` called the `get_all_providers` this commit removes.

**A real bug fell out of this**, not in the residue list: `claude` sat third in
the auto-selection order, but `async_get_text_completion`'s claude arm logged
"not supported yet" and returned `None` *without trying the next available
provider*, and `async_get_structured_output` has no claude arm at all — so an
`ANTHROPIC_API_KEY`-only deployment got silence from both helpers. It is out of
the auto-selection list; such a deployment now falls through to a provider that
answers. Agent chat is unaffected (it reaches Claude via `PROVIDERS_DEEP`).

### 4. `<PROVIDER>_EMBEDDING_MODEL`

The last table of model ids config could not reach. config.yaml recommends
self-hosting Qwen3-Embedding-8B and pointing `OPENROUTER_BASE_URL` at it — but
there was no way to say what that serving calls the model, so the request went
out as `qwen/qwen3-embedding-8b` and 404'd; the only escape was switching
provider (what the #52 E2E had to do).

`embedding_model_id()` reads the override first. Both sides already went through
that one function, so it lands on the request bodies *and* on the identity stamp
`indicator/semantic.py` checks: an override against a matrix built with the old
model raises "built by X, queries embedded by Y" instead of ranking in the wrong
vector space. `scripts/build_loinc_embeddings.py` reads the same key plus
`<PROVIDER>_BASE_URL` for the endpoint it had hardcoded — corpus and queries
have to come out of one serving. `dimensions: 1024` stays a literal on purpose:
that is the database column width, a schema fact.

### Verification

- `mirobody/` 276 passed; full local suite 1,018 passed / 3 skipped
- `lint-imports` 3 contracts KEPT; `stamp_bundle_version --check`,
  `build_runtime_index --check` OK
- `python -m build` + `check_wheel_data.py` clean; bare wheel install in a fresh
  uv venv is still **2 packages** (mirobody + numpy)
- `eval/run_eval.py --no-embed`: 7,354 cases, coverage 0.9631, wrong 0.0322
  (resolver untouched)

Not verified: real Ark and real Anthropic traffic (no keys here), and the
browser E2E was not re-run this round.

Left deliberately open: merging the two provider-configuration systems
(`utils/config/llm.py` vs `utils/llm/config.py`). `docs/roadmap.md` asks for
per-provider characterisation tests first; this PR only updates the counts that
entry cites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
