### PR TITLE
docs: backup and restore, with the nightly script (closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@
   by construction — and a mismatch still fails loudly rather than ranking in
   the wrong vector space.
 
+- **Backup and restore are documented** ([docs/backup-restore.md](docs/backup-restore.md)),
+  with `shell/backup.sh` for the nightly job. It says which of the four compose
+  volumes actually hold irreplaceable data (Postgres and, only when files are
+  stored locally, the uploads) and which must never be restored (the
+  site-packages pip cache), and it takes `pg_dump` rather than tarring a
+  running cluster's data directory. Both directions were run end to end while
+  writing it, including a restore into a scratch database.
+
 ### Removed
 
 - **`volcengine-python-sdk[ark]` is no longer a dependency** of `[app]`. It

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ notes to PyPI under a filename that told open-source readers to ignore it.
 | ① | [file-processing.md](file-processing.md) | the file-parsing pipeline (8 formats, LLM extraction) |
 | ① | [apple-health.md](apple-health.md) | Apple Health export + CDA import |
 | ③ | [frontend.md](frontend.md) | how the bundled web client is served, and how to replace it |
+| | [backup-restore.md](backup-restore.md) | what to copy, how to get it back, and what changes on upgrade |
 | | [testing.md](testing.md) | test layout, markers, snapshots, release gates |
 | | [aggregation-tests.md](aggregation-tests.md) | the daily-rollup test suite in detail |
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,164 @@
+# Backing up and restoring
+
+Health data is irreplaceable — a reading you lose is a blood draw you cannot
+repeat. This page is the answer to "what do I copy, and how do I get it back".
+
+Every command here was run against a live stack while writing it, including the
+restore: the dump below was restored into a scratch database and came back with
+29 tables in the `theta_ai` schema and the `vector` extension in place.
+
+## What actually holds your data
+
+`compose.yaml` declares four volumes. They are not equally precious, and
+treating them alike is how people back up a pip cache and miss their uploads.
+
+| Declared in compose | Holds | Back it up? |
+| --- | --- | --- |
+| `mirobody_postgres` | Everything the app knows: readings, files metadata, care circles, users — plus LangGraph's `checkpoint_*` conversation memory when `AGENT_CHECKPOINTER: true`. All inside the `PG_SCHEMA` schema (`theta_ai`), with `vector(1024)` columns and an hnsw index. | **Yes — `pg_dump`.** Not a tar of the data directory (see below). |
+| `mirobody_upload` | The original uploaded PDFs and photos — **only when files are stored locally.** | **Yes, if it exists.** `storage/factory.py` tries each cloud backend (Aliyun OSS, AWS S3) first and falls back to local, so a deployment with either configured keeps its files in a bucket: back up the bucket, and this volume will be absent or empty. |
+| `mirobody_redis` | The worker's task queues (`LPUSH`/`BLPOP` lists, no TTL) and the distributed locks — which is why compose runs redis with `--maxmemory-policy noeviction --appendonly yes`. | **No, by default.** This is in-flight work, not history. Restoring a stale AOF re-runs tasks that already ran, or silently drops ones that had not. `INCLUDE_REDIS=1` captures it for forensics. |
+| `mirobody_site_packages` | A pip cache, keyed on a hash of `pyproject.toml` + `requirements.txt`. | **Never.** It is derived, and restoring it reinstates dependencies the current code no longer imports — the release that dropped a 245 MB vendor SDK would get it back. Delete the volume and the next start reinstalls. |
+
+There is **no `mirobody_charts` volume**. The `ChartService` MCP tools that
+rendered PNGs through a Node toolchain were removed; DeepAgent now writes a
+fenced ```vis-chart``` data block that the frontend renders, so nothing writes
+chart files at all.
+
+### Two things that make copy-pasted commands fail silently
+
+**Volume names are project-prefixed.** The volume declared as
+`mirobody_upload` is `<project>_mirobody_upload` on the daemon — for a checkout
+in `mirobody/`, that is `mirobody_mirobody_upload`. `docker volume ls` shows
+the real names. This matters because getting it wrong does not error:
+
+```bash
+# WRONG — creates a NEW empty volume and tars nothing. Exit code 0.
+docker run --rm -v mirobody_upload:/data:ro -v "$PWD":/b alpine tar czf /b/x.tar.gz /data
+```
+
+`shell/backup.sh` checks `docker volume inspect` before reading anything, so a
+name that does not exist is reported rather than archived as 45 empty bytes.
+
+**Container names come from service names.** There is no `container_name:` in
+`compose.yaml` and the database service is `pg`, so the container is
+`mirobody-pg-1`, not `mirobody-db-1`. Prefer `docker compose exec pg …`, which
+does not care what the container is called.
+
+## Backing up
+
+```bash
+shell/backup.sh                                  # -> ./backups
+BACKUP_DIR=/mnt/nas/mirobody shell/backup.sh     # somewhere that is not this disk
+RETENTION_DAYS=30 INCLUDE_REDIS=1 shell/backup.sh
+```
+
+Nightly, via cron:
+
+```cron
+0 3 * * *  cd /srv/mirobody && BACKUP_DIR=/mnt/nas/mirobody shell/backup.sh >> /var/log/mirobody-backup.log 2>&1
+```
+
+What it does, and why:
+
+- **`pg_dump -Fc`, not a tar of `/var/lib/postgresql/data`.** Tarring a running
+  cluster copies files that are moving under the tar; the result restores, or
+  does not, depending on timing. `pg_dump` is consistent by construction and
+  restores into any pgvector image rather than only a byte-identical one.
+- **The dump is verified before the run is called a success.** `pg_restore
+  --list` parses the archive's table of contents, which fails on a truncated or
+  empty file. A backup nobody has read is a hope, not a backup.
+- **The dump is written and verified inside the container, then copied out.** A
+  custom-format archive is not seekable through a pipe, so verification cannot
+  read one from stdin, and `pg_dump > file` that dies half-way leaves a
+  plausible-looking truncated file.
+- **Uploads are archived only if the local volume exists** (see the table).
+- **Retention is pattern-scoped** — it prunes `mirobody-db-*.dump`,
+  `mirobody-uploads-*.tar.gz` and `mirobody-redis-*.tar.gz` older than
+  `RETENTION_DAYS`, and leaves anything else in the directory alone.
+
+The script is backup-only on purpose. Restore stays a human decision: the one
+time you need it, you want to be reading the steps.
+
+## Restoring
+
+Stop the app first so nothing writes while the schema is being replaced. Keep
+`pg` running — it is what does the restoring.
+
+```bash
+docker compose stop mirobody mirobody_worker
+```
+
+### Database
+
+Into a **fresh** database (the safe path — the old one stays until you are
+satisfied):
+
+```bash
+docker compose cp backups/mirobody-db-20260902-153442.dump pg:/tmp/restore.dump
+docker compose exec -T pg createdb -U holistic_user holistic_db_restored
+docker compose exec -T pg pg_restore -U holistic_user -d holistic_db_restored --no-owner /tmp/restore.dump
+# sanity-check before switching over
+docker compose exec -T pg psql -U holistic_user -d holistic_db_restored -c \
+  "select count(*) from information_schema.tables where table_schema='theta_ai'"
+```
+
+Then point `PG_DBNAME` at `holistic_db_restored` in your config and start the
+app. To restore over the existing database instead, add `--clean` (it drops
+each object before recreating it) and be aware that there is no undo:
+
+```bash
+docker compose exec -T pg pg_restore -U holistic_user -d holistic_db --clean --no-owner /tmp/restore.dump
+```
+
+A note on the vector columns: they restore as ordinary data, and the pinned
+`pgvector/pgvector` image already has the extension, so **no re-embedding is
+needed** after a restore. (Re-embedding is only for changing
+`EMBEDDING_PROVIDER` or `<PROVIDER>_EMBEDDING_MODEL`.)
+
+### Uploaded files
+
+```bash
+docker run --rm \
+  -v mirobody_mirobody_upload:/data \
+  -v "$PWD/backups":/backup \
+  alpine tar xzf /backup/mirobody-uploads-20260902-153442.tar.gz -C /data
+```
+
+Check the real volume name with `docker volume ls` first. The archive is made
+with `-C /data .`, so it extracts as the volume's contents, not as a nested
+`data/` directory.
+
+### Then
+
+```bash
+docker compose up -d
+```
+
+## Before upgrading
+
+1. **Run `shell/backup.sh` and keep the output off this machine.** This is the
+   whole checklist, because it is also the rollback: there are no down
+   migrations.
+2. Read `CHANGELOG.md` for the version you are moving to.
+3. `git pull && ./deploy.sh` — the script takes no arguments and already does
+   `compose down`, then `up -d --remove-orphans`, then tails the logs.
+4. Watch that log tail: the schema DDL runs on the first start (see below), and
+   a file that fails is logged with its `sql_filename`.
+
+### How the schema actually changes
+
+`server/bootstrap.py::create_schema` replays **every** file in
+`mirobody/schema/*.sql`, in filename order, on each start. Every file is
+written to be safely re-runnable — there is no ledger of what has been applied,
+and no schema-version table by design. Verified by running the whole set three
+times against a clean database: zero errors. A failing file is rolled back on
+its own and logged; the rest still run, so one bad increment cannot leave half
+a schema with no explanation.
+
+Two consequences worth knowing:
+
+- **Upgrades are additive.** A new release adds tables or columns on first
+  start; you do not run a migration command.
+- **There is no automated downgrade.** Rolling back a release that added a
+  column means restoring the dump you took in step 1. That is why step 1 is
+  step 1.

--- a/shell/backup.sh
+++ b/shell/backup.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Back up the two volumes that hold irreplaceable data: the Postgres database
+# (health readings, care circles, LangGraph conversation checkpoints) and the
+# uploaded files, when they live locally rather than in a bucket.
+#
+# Backup only, on purpose. Restore is documented in docs/backup-restore.md and
+# stays a human decision: a script that runs psql against a live database is a
+# footgun, and the one time you need it you want to be reading the steps.
+#
+# Usage:
+#   shell/backup.sh                       # -> ./backups
+#   BACKUP_DIR=/mnt/nas/mirobody shell/backup.sh
+#   RETENTION_DAYS=30 INCLUDE_REDIS=1 shell/backup.sh
+#   0 3 * * *  cd /srv/mirobody && BACKUP_DIR=/mnt/nas/mirobody shell/backup.sh >> /var/log/mirobody-backup.log 2>&1
+#
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+INCLUDE_REDIS="${INCLUDE_REDIS:-0}"
+PG_USER="${PG_USER:-holistic_user}"
+PG_DB="${PG_DB:-holistic_db}"
+
+# Compose prefixes every volume with the project name, so the volume declared
+# as `mirobody_upload` is really `<project>_mirobody_upload` on the daemon.
+# Getting this wrong does not fail: `docker run -v mirobody_upload:/data`
+# CREATES a new empty volume and tars nothing, which is why every volume below
+# is checked to exist before it is read.
+PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}"
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$BACKUP_DIR"
+
+log() { printf '%s  %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+have_volume() { docker volume inspect "$1" >/dev/null 2>&1; }
+
+#-----------------------------------------------------------------------------
+# 1. Postgres — logical dump, not a tar of the data directory.
+#
+# `docker run -v <pgdata>:/data:ro alpine tar` on a RUNNING server copies a
+# torn cluster: the files move under the tar. pg_dump is consistent by
+# construction (it runs in one transaction) and restores into any pgvector
+# image, not only a byte-identical one.
+#-----------------------------------------------------------------------------
+if ! docker compose ps --services --status running 2>/dev/null | grep -qx pg; then
+    log "FATAL: compose service 'pg' is not running — start the stack, or dump from wherever your database actually runs."
+    exit 1
+fi
+
+DUMP="$BACKUP_DIR/mirobody-db-$STAMP.dump"
+STAGED="/tmp/mirobody-db-$STAMP.dump"
+log "dumping database $PG_DB (custom format) -> $DUMP"
+
+# Dumped and verified INSIDE the container, then copied out — deliberately not
+# `pg_dump ... > file` on the host. Two reasons, both learned by running it:
+# a custom-format archive is not seekable through a pipe, so the verification
+# below cannot read one from stdin ("did not find magic string in file header"
+# on a file whose header is fine); and a dump that dies half-way through a
+# redirect leaves a plausible-looking truncated file behind.
+#
+# A backup nobody has read is a hope, not a backup: pg_restore --list parses
+# the archive's table of contents, so it fails on a truncated or empty file.
+docker compose exec -T pg sh -c \
+    "pg_dump -U '$PG_USER' -d '$PG_DB' -Fc -f '$STAGED' && pg_restore --list '$STAGED' > /dev/null"
+docker compose cp "pg:$STAGED" "$DUMP"
+docker compose exec -T pg rm -f "$STAGED"
+log "dump verified readable ($(du -h "$DUMP" | cut -f1))"
+
+#-----------------------------------------------------------------------------
+# 2. Uploaded files — only when they are on this host.
+#
+# storage/factory.py tries each cloud backend (Aliyun OSS, AWS S3) first and
+# falls back to local, so a deployment with either configured keeps its files
+# in a bucket and this volume is empty or absent. Back up the bucket instead;
+# this script says so rather than writing a 45-byte tar that looks like success.
+#-----------------------------------------------------------------------------
+UPLOAD_VOLUME="${PROJECT}_mirobody_upload"
+if have_volume "$UPLOAD_VOLUME"; then
+    FILES="$BACKUP_DIR/mirobody-uploads-$STAMP.tar.gz"
+    log "archiving $UPLOAD_VOLUME -> $FILES"
+    docker run --rm \
+        -v "$UPLOAD_VOLUME":/data:ro \
+        -v "$(cd "$BACKUP_DIR" && pwd)":/backup \
+        alpine tar czf "/backup/$(basename "$FILES")" -C /data .
+    log "uploads archived ($(du -h "$FILES" | cut -f1))"
+else
+    log "skip: no volume $UPLOAD_VOLUME. Either this deployment stores files in a bucket (back up the bucket), or the stack has never written an upload."
+fi
+
+#-----------------------------------------------------------------------------
+# 3. Redis — off by default.
+#
+# It holds the worker's task queues (LPUSH/BLPOP lists, no TTL) and the
+# distributed locks, which is why compose runs it with `noeviction` and
+# `appendonly yes`. That is IN-FLIGHT work, not history: restoring a stale AOF
+# re-runs tasks that already ran, or drops ones that did not. INCLUDE_REDIS=1
+# captures it anyway for forensics.
+#-----------------------------------------------------------------------------
+if [ "$INCLUDE_REDIS" = "1" ]; then
+    REDIS_VOLUME="${PROJECT}_mirobody_redis"
+    if have_volume "$REDIS_VOLUME"; then
+        AOF="$BACKUP_DIR/mirobody-redis-$STAMP.tar.gz"
+        log "archiving $REDIS_VOLUME -> $AOF (forensics only — see docs/backup-restore.md)"
+        docker compose exec -T redis redis-cli -a "${REDIS_PASSWORD:-}" --no-auth-warning BGSAVE >/dev/null 2>&1 || true
+        docker run --rm \
+            -v "$REDIS_VOLUME":/data:ro \
+            -v "$(cd "$BACKUP_DIR" && pwd)":/backup \
+            alpine tar czf "/backup/$(basename "$AOF")" -C /data .
+    else
+        log "skip: no volume $REDIS_VOLUME"
+    fi
+fi
+
+# The site-packages volume is deliberately never here: it is a pip cache keyed
+# on a hash of pyproject.toml + requirements.txt, and restoring it reinstates
+# dependencies the current code no longer imports (1.4.0 dropped a 245 MB SDK
+# that a restored volume would put straight back).
+
+#-----------------------------------------------------------------------------
+# 4. Retention — pattern-scoped, so a BACKUP_DIR that holds anything else
+#    keeps it.
+#-----------------------------------------------------------------------------
+if [ "$RETENTION_DAYS" -gt 0 ]; then
+    log "pruning backups older than $RETENTION_DAYS days"
+    find "$BACKUP_DIR" -maxdepth 1 -type f \
+        \( -name 'mirobody-db-*.dump' -o -name 'mirobody-uploads-*.tar.gz' -o -name 'mirobody-redis-*.tar.gz' \) \
+        -mtime "+$RETENTION_DAYS" -print -delete
+fi
+
+log "done. Restore steps: docs/backup-restore.md"


### PR DESCRIPTION
Closes #21. Also covers the documentation half of #16 (the code half of that
issue is void — see the comment there).

There was no backup documentation at all: `pg_dump` appears nowhere in the
repository, and for a project whose premise is that a person keeps their own
health record, "health data is irreplaceable" was a claim with no procedure
behind it.

### The issues' own commands were stale, in ways that fail quietly

- **`mirobody_charts` does not exist.** The `ChartService` MCP tools that
  rendered PNGs through a Node toolchain were removed; DeepAgent writes a
  ```vis-chart``` block the frontend renders, so nothing writes chart files.
- **Volume names are project-prefixed.** `mirobody_upload` is really
  `<project>_mirobody_upload`, so `docker run -v mirobody_upload:/data:ro … tar`
  **creates a new empty volume and archives nothing, exit code 0.** The script
  runs `docker volume inspect` before reading anything.
- **The database service is `pg`**, so the container is `mirobody-pg-1`, not
  `mirobody-db-1`. Commands use `docker compose exec pg`.
- **`./deploy.sh --mode=build`** — deploy.sh takes no arguments and already does
  `compose down`, `up -d --remove-orphans`, then tails logs.
- **Tarring a running cluster's data directory** copies files that move under
  the tar. `pg_dump` is consistent by construction.

### The part neither issue had: the four volumes are not equally precious

| Volume | Back up? | Why |
| --- | --- | --- |
| `mirobody_postgres` | **yes, `pg_dump`** | everything, plus LangGraph `checkpoint_*` conversation memory; all in the `theta_ai` schema with `vector(1024)` + hnsw |
| `mirobody_upload` | **yes, if it exists** | `storage/factory.py` prefers OSS/S3 and falls back to local — a cloud deployment's real target is the bucket |
| `mirobody_redis` | **no, by default** | worker task queues (`LPUSH`/`BLPOP`, no TTL) and locks; in-flight work, so a stale AOF re-runs or drops it. `INCLUDE_REDIS=1` for forensics |
| `mirobody_site_packages` | **never** | pip cache keyed on a hash of pyproject+requirements; restoring it reinstates dependencies the code no longer imports — the 245 MB SDK dropped in this same release would come straight back |

### Verified by running it, both directions

- `shell/backup.sh` against the live stack: dumps `holistic_db`, verifies the
  archive, skips the absent upload volume **with a message** rather than writing
  45 empty bytes, prunes by pattern.
- The dump restored into a scratch database: **29 tables in `theta_ai`, `vector`
  extension present** — so no re-embedding after a restore (that is only for
  changing the embedding provider/model). Scratch database dropped afterwards.
- The uploads tar round-tripped through two scratch volumes with content intact.

Running it is what produced the script's shape: `pg_dump > file` on the host
cannot be verified, because a custom-format archive is not seekable through a
pipe — `pg_restore --list` reported *"did not find magic string in file header"*
for a file whose header was fine. So it dumps and verifies **inside** the
container, then copies out.

Backup is scripted; restore is documented and stays a human decision — a script
that runs `psql` against a live database is a footgun, and the one time you need
it you want to be reading the steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
