### PR TITLE
readme: point the Star History chart back at star-history.com

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -440,11 +440,11 @@ mirobody は健康データの標準化と推論を行うものであり、デ�
 ## ⭐ Star の推移
 
 <div align="center">
-<a href="https://star-history.dera.page/#thetahealth/mirobody&Date">
+<a href="https://www.star-history.com/#thetahealth/mirobody&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
-    <img alt="Star 推移グラフ" src="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
+    <img alt="Star 推移グラフ" src="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
   </picture>
 </a>
 </div>

--- a/README.md
+++ b/README.md
@@ -486,11 +486,11 @@ none of their code is included here:
 ## ⭐ Star History
 
 <div align="center">
-<a href="https://star-history.dera.page/#thetahealth/mirobody&Date">
+<a href="https://www.star-history.com/#thetahealth/mirobody&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
   </picture>
 </a>
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -421,11 +421,11 @@ mirobody 做的是健康数据的标准化与推理，不追求成为接入设�
 ## ⭐ Star 趋势
 
 <div align="center">
-<a href="https://star-history.dera.page/#thetahealth/mirobody&Date">
+<a href="https://www.star-history.com/#thetahealth/mirobody&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
-    <img alt="Star 趋势图" src="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
+    <img alt="Star 趋势图" src="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
   </picture>
 </a>
 </div>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -418,11 +418,11 @@ mirobody 做的是健康資料的標準化與推理，不追求成為接入裝�
 ## ⭐ Star 趨勢
 
 <div align="center">
-<a href="https://star-history.dera.page/#thetahealth/mirobody&Date">
+<a href="https://www.star-history.com/#thetahealth/mirobody&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
-    <img alt="Star 趨勢圖" src="https://star-history.dera.page/svg?repos=thetahealth/mirobody&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
+    <img alt="Star 趨勢圖" src="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
   </picture>
 </a>
 </div>


### PR DESCRIPTION
The Star History chart in all four READMEs has been stuck since late August. The mirror it points at stopped collecting data.

## What is wrong

`star-history.dera.page` draws this repo's curve up to **2026-08-24**, peaking at **~1,059** stars. The repo is at **1,292** today, so the entire 9/1 run-up is missing from the chart.

Two things it is not:

- **Not a CDN cache.** A request with a random cache-busting parameter returns a byte-identical 62,490-byte SVG. The mirror's own dataset is frozen.
- **Not specific to this repo.** `langchain-ai/langchain` and `vllm-project/vllm` both come back with curves ending on the same date.

Read off the axes rather than the status code — a stale chart is still a 200:

| | dera.page | api.star-history.com | GitHub API |
| --- | --- | --- | --- |
| x-scale | 2.612 px/day | 2.466 px/day | — |
| right edge (x=700) | 2026-08-24 | 2026-09-09 | — |
| y-axis top / peak | 1000 / ~1,059 | 1200 / ~1,293 | **1,292 stars** |

## Why it was pointed there

06e3559 moved off `api.star-history.com` on 8/31 because it was answering *every* repo with a "GitHub restricted access to star data" placeholder — a 200, `image/svg+xml`, ~60 KB, so only the text nodes gave it away. That was correct at the time.

That restriction has been lifted. Both the light and dark endpoints now draw the real curve through today; their text nodes were checked for the restriction notice and it is absent.

## The change

Three URLs per file, four files:

- `star-history.dera.page/svg?` → `api.star-history.com/svg?` (dark source, light source, `img` fallback)
- `star-history.dera.page/#` → `www.star-history.com/#` — the `www` host is what the bare domain 301s to, so the `#owner/repo&Date` fragment does not have to survive a redirect

Changing the URL also gives GitHub's camo proxy a new cache key, so the chart refreshes on merge rather than waiting out the old entry.

## Verification

- `pytest -q mirobody/test_readme_*.py` — **51 passed** (the four README gates)
- Both SVG endpoints fetched: 200, `image/svg+xml`, 64.5 KB, no restriction text, curve to 2026-09-09
- Interactive link fetched on the `www` host: 200
- No `dera.page` reference remains in any README

🤖 Generated with [Claude Code](https://claude.com/claude-code)
