### PR TITLE
readme: Collect · Translate · Answer, two live editions, and half the length

### DIFF
--- a/.github/ISSUE_TEMPLATE/wrong-term.yml
+++ b/.github/ISSUE_TEMPLATE/wrong-term.yml
@@ -1,0 +1,51 @@
+name: The resolver got a term wrong
+description: "`mirobody resolve <term>` answered the wrong code, or nothing, for a term a real report prints."
+title: "resolve: <term> → <what you got>"
+labels: ["resolver", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is the highest-leverage report the project takes. A fix is one row in
+        `mirobody/res/resolver_overrides.tsv` plus one case in
+        `mirobody/test_engine_coverage.py`; the coverage score is the review.
+  - type: input
+    id: term
+    attributes:
+      label: The term, exactly as the report prints it
+      placeholder: "Lipid-Small Dense Low-Density Lipoprotein Cholesterol"
+    validations:
+      required: true
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language of the term
+      options: [English, 简体中文, 繁體中文, 日本語, Other]
+    validations:
+      required: true
+  - type: input
+    id: got
+    attributes:
+      label: What `mirobody resolve` answered
+      description: Paste the line it printed, or "unresolved".
+    validations:
+      required: true
+  - type: input
+    id: expected
+    attributes:
+      label: The LOINC code you expected (if you know it)
+      placeholder: "718-7"
+  - type: input
+    id: unit
+    attributes:
+      label: Unit and a sample value, if the report shows one
+      placeholder: "4.2 10*9/L"
+  - type: dropdown
+    id: source
+    attributes:
+      label: Where the term comes from
+      options: [Checkup / lab report, Hospital record, Wearable or app export, Other]
+  - type: input
+    id: version
+    attributes:
+      label: "`mirobody --version` and `python -c 'import mirobody; print(mirobody.BUNDLE_VERSION)'`"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,10 +184,12 @@ documentation belongs in.
 
 ### Translations
 
-The README ships in English, 简体中文, 繁體中文 and 日本語; the web client ships
-the same four. **English is the source of truth** — change it first, then the
-others, and if you only change English say so in the PR so the drift is visible
-instead of silent.
+The README ships in English and Chinese; the web client ships four languages.
+**English is the source of truth** — change it first, then Chinese, and if you
+only change English say so in the PR so the drift is visible instead of silent.
+The 繁體中文 and 日本語 READMEs are frozen at 1.4.0 under
+[`archived/`](archived/README.md); the engine's Traditional Chinese and Japanese
+support is unaffected and still gated by `test_engine_coverage.py`.
 
 Two rules that are specific to this project:
 
@@ -211,8 +213,9 @@ while looking correct.
 
 UI strings are **not** in this repo. `frontend/` holds the built web client, not
 its source, so there is no `i18n/` here to edit. What is translatable here is the
-four READMEs — `README.md` plus `.zh-CN` / `.zh-TW` / `.ja` — and they are checked
-as a set by `mirobody/test_readme_links.py` and `mirobody/test_readme_numbers.py`.
+two live READMEs — `README.md` and `README.zh-CN.md` — and they are checked as a
+set by `mirobody/test_readme_links.py`, `mirobody/test_readme_numbers.py`,
+`mirobody/test_readme_examples.py` and `mirobody/test_readme_l10n.py`.
 Everything under `docs/` and every in-package `README.md` stays English.
 
 ### Commits

--- a/README.md
+++ b/README.md
@@ -1,44 +1,31 @@
 <div align="center">
 
-# 🚀 Mirobody
+# Mirobody
 
-**The AI-native health data engine — collect, standardize, and reason over labs, wearables & genomics.**
+**The AI-native health data engine — Collect · Translate · Answer.**
 
-Mirobody powers **Theta Wellness**, a live consumer health product used by 5,000+ registered users with 500+ daily active users.
+Lab reports, wearables and genomics become one language AI can read:
+LOINC-coded, UCUM-normalized, FHIR-ready. The resolver runs offline, and the
+engine powers **[Theta Wellness](https://www.thetahealth.ai/)**, a live consumer
+health product with 5,000+ registered users and 500+ daily active.
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)
-[![Benchmarks](https://img.shields.io/badge/%F0%9F%A4%97_Benchmarks-4k%2B_downloads_each-FFD21E.svg)](https://huggingface.co/healthmemoryarena)
+[![Benchmarks](https://img.shields.io/badge/%F0%9F%A4%97_Benchmarks-4k%2B_downloads_each-FFD21E.svg)](https://huggingface.co/mirobody)
 [![arXiv](https://img.shields.io/badge/arXiv-2604.02834-b31b1b.svg)](https://arxiv.org/abs/2604.02834)
 [![Docs](https://img.shields.io/badge/Docs-docs.mirobody.ai-black)](https://docs.mirobody.ai/)
+[![GitHub stars](https://img.shields.io/github/stars/thetahealth/mirobody?style=social)](https://github.com/thetahealth/mirobody/stargazers)
 
-**[📚 Documentation](https://docs.mirobody.ai/)** · **[💬 Hosted chat — chat.mirobody.ai](https://chat.mirobody.ai/)** · **[🔌 API platform — platform.mirobody.ai](https://platform.mirobody.ai/)**
+**[📚 Documentation](https://docs.mirobody.ai/)** · **[▶ Live demo](https://chat.mirobody.ai/)** · **[🔌 API platform](https://platform.mirobody.ai/)**
 
-**English** · **[简体中文](README.zh-CN.md)** · **[繁體中文](README.zh-TW.md)** · **[日本語](README.ja.md)**
-
-*Blood tests, wearables, genomics, imaging — all fragmented, all incompatible.
-Before AI can understand your health, someone has to unify these signals into a
-single standard AI can actually read. That is what this engine does.*
-
-<img src="docs/images/where-your-data-comes-from.svg" alt="From wearables to food photos — one standard format, ready for AI." width="920">
+**English** · **[中文](README.zh-CN.md)**
 
 </div>
 
-The engine does three things, and the codebase (and [Contributing](#-contributing)) is organized around exactly these three stages — the same **C · S · A** the [documentation](https://docs.mirobody.ai/en/api-reference/) uses:
-
-| Stage                | What it means                                                                                                     | Where                                                   |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **① Collect** | Pull signals in: 3 device providers + a SQL source · 7 file formats · Apple Health (receive-only: a signed iOS client POSTs it in) | [`pulse/`](mirobody/pulse/) |
-| **② Standardize**    | One standard: resolve any reading to canonical codes (LOINC · SNOMED CT · RxNorm), normalize units, land against FHIR-recognized code systems | [`indicator/`](mirobody/indicator/)                    |
-| **③ Answers**  | Reason: agents read the *original documents* through a virtual filesystem and answer with charts & citations     | [`agent/`](mirobody/agent/)                  |
-
----
-
 ## ⚡ Try it in 60 seconds
 
-Indicator resolution is the engine's front door and needs no key, no config and
-no network:
+No key, no config, no network:
 
 ```bash
 pip install mirobody
@@ -50,7 +37,9 @@ mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖
        alt="mirobody resolve: four languages landing on one LOINC code, fully offline" width="880">
 </p>
 
-> Real output, and the GIF is a build artifact — [`docs/demo/resolve.html`](docs/demo/resolve.html) rendered by [`scripts/make_demo_gifs.py`](scripts/make_demo_gifs.py), so it cannot drift away from the command it claims to show.
+`血红蛋白` and `ヘモグロビン` land on the same code as `hemoglobin`, LOINC `718-7`;
+`空腹血糖(GLU)` on fasting glucose. `血脂` (lipids) is a category, not an
+observation, so the resolver returns nothing rather than a plausible wrong code.
 
 ```python
 from mirobody.engine import resolve, resolve_reading
@@ -66,422 +55,197 @@ resolve_reading("中性粒细胞", "4.2", "10*9/L").loinc       # '26499-4' ...a
 resolve("血脂").resolved                                 # False    a category, not an observation
 ```
 
-**Pass the value and the unit when you have them.** LOINC encodes the unit *and*
-the result type into the identity, so the same name resolves to different codes —
-filing a mmol/L result under a mg/dL code is how one series quietly ends up
-holding two units. `resolve` abstains rather than guessing: `""` is a gap worth a
-second look, `"refused"` is the answer.
-→ [Engine reference](https://docs.mirobody.ai/en/engine/) ·
-[Indicators](https://docs.mirobody.ai/en/concepts/indicators/)
+**Pass the value and the unit when you have them.** LOINC encodes the unit and
+the result type into the identity, so the same name resolves to different codes.
+`resolve` abstains rather than guessing: an empty code is a gap worth a second
+look; `method="refused"` is a decision.
+→ [Engine reference](https://docs.mirobody.ai/en/engine/) · [Indicators](https://docs.mirobody.ai/en/concepts/indicators/)
 
----
+## Why Mirobody
 
-## What the standardization layer provides
+- **Two reports, same test, different spelling and units.** That is the problem.
+  Mirobody translates any reading, in any language, to LOINC + UCUM — and refuses
+  to guess when it does not know the term.
+- **AI can only reason over what it can read.** The agent reads the original
+  documents, charts lab draws against sensor-derived series, and cites the page
+  it read from.
+- **Self-hosted, standards-based, Apache-2.0.** One `./deploy.sh` runs the whole
+  stack on your own machine; what comes out is LOINC-coded, FHIR-ready records
+  you can take anywhere, and the same tools are served over MCP to Claude
+  Desktop, Cursor or your own agent.
 
-Standardization here is not a lookup table but a complete terminology-normalization system:
+## Collect · Translate · Answer
 
-- **Concept graph**: 440,961 nodes · 22,044,110 cross-vocabulary edges ·
-  **595,746 source ids** distilled into canonical concepts (LOINC · SNOMED CT ·
-  RxNorm bridges).
-- **49,253 multilingual aliases** (中文 22,578 · 日本語 16,809 · +5:
-  de·es·fr·ko·ru). `hemoglobin`, `血红蛋白`, `血紅素` and `ヘモグロビン` all land
-  on LOINC 718-7.
-- **繁體中文 is two problems, handled as two.** Script folding is mechanical
-  (a shipped 3,336-character zh-Hant → zh-Hans table); vocabulary is not — Taiwan
-  usage picks different words, and folding `血紅素` yields the HbA1c code. Those
-  terms are curated under their Traditional spelling, and a curated row always
-  beats a fold.
-- **Units** normalized to ~310 UCUM families, with dimensional analysis, a
-  molar-mass bridge keyed by LOINC code, and an explicit refusal for `%` vs
-  `10*9/L`. 305 standard pulse indicators.
-- **A second tier exists, and stays opt-in.** Everything above is lexical, so it
-  abstains on terms it does not know — an honest ceiling. Cosine recall
-  ([`indicator/semantic.py`](mirobody/indicator/semantic.py)) reaches past it but
-  **cannot abstain**: for a term it has never seen it returns its nearest
-  neighbour with the confidence of a correct answer, and no threshold separates
-  the two. **No matrix ships and none is published to download**: it is 108,248
-  LOINC rows × 1024 dims (~221 MB) and it is specific to one (provider, model)
-  pair, so `scripts/build_loinc_embeddings.py` builds yours against the
-  embedding model you configure. A matrix from a different model does not
-  error — it ranks confidently in the wrong space, which is why the build
-  stamps `<matrix>.meta.json` and loading refuses a mismatch. Until you point
-  `MIROBODY_SEMANTIC_INDEX` at one, `resolve()` is unchanged; after, use it to
-  *suggest* a code a human confirms, never to mint an identity.
-  → [Semantic recall](https://docs.mirobody.ai/en/concepts/semantic-recall/) — the
-  benchmark, the two axis gates, and why `min_score` is not a correctness threshold.
-- **We measure the claim instead of asserting it.**
-  [`test_engine_coverage.py`](mirobody/test_engine_coverage.py) scores the offline
-  resolver against the panels an ordinary checkup includes, written the way a report
-  prints them, in English, 简体中文, 繁體中文 and 日本語 — plus the wearable
-  vocabulary the platform API teaches. **211/211 today; it scored 32/94 the day it
-  was written.** It grades *clinical* correctness: answering `血红蛋白` with the
-  HbA1c code is a failure, and `血脂` is required to resolve to nothing.
+<p align="center">
+  <img src="docs/images/where-your-data-comes-from.svg" alt="From wearables to food photos — one standard format, ready for AI." width="920">
+</p>
 
-```bash
-pytest mirobody/test_engine_coverage.py -s   # offline, about a second
-```
+The engine does three things, and the codebase, the docs and
+[Contributing](#-contributing) are organized around exactly these three stages:
 
-### Which LOINC, and what it does and does not cover
+| Stage | What it means | Where |
+| --- | --- | --- |
+| **① Collect** | Pull signals in: 3 device providers + a SQL source · 7 file formats · Apple Health (receive-only: a signed iOS client POSTs it in) | [`pulse/`](mirobody/pulse/) |
+| **② Translate** (standardize) | One standard: resolve any reading to canonical codes (LOINC · SNOMED CT · RxNorm), normalize units to UCUM, land on FHIR-recognized code systems | [`indicator/`](mirobody/indicator/) |
+| **③ Answer** (agent) | Reason: an agent reads the *original documents* through a virtual filesystem and answers with charts and citations | [`agent/`](mirobody/agent/) |
 
-The shipped bundle is cut from **LOINC 2.82**, and the package says so at
-runtime rather than in a comment that can drift:
+## By the numbers
 
-```python
->>> import mirobody; mirobody.BUNDLE_VERSION
-'loinc-2.82+2026.08.28-af2524b7a285'
-```
+| | |
+| --- | --- |
+| Concept graph | 440,961 nodes · 22,044,110 cross-vocabulary edges · 595,746 source ids distilled into canonical concepts (LOINC · SNOMED CT · RxNorm bridges) |
+| Aliases | 49,253 multilingual (中文 22,578 · 日本語 16,809 · de·es·fr·ko·ru); `hemoglobin`, `血红蛋白`, `血紅素` and `ヘモグロビン` all land on 718-7 |
+| Traditional Chinese | a shipped 3,336-character zh-Hant → zh-Hans fold table, plus curated Traditional rows — a curated row always beats a fold |
+| Units | ~310 UCUM families with dimensional analysis and a molar-mass bridge keyed by LOINC code; 305 standard pulse indicators |
+| Coverage | **211/211** on the panels an ordinary checkup prints, in English, Chinese (Simplified and Traditional) and Japanese ([`test_engine_coverage.py`](mirobody/test_engine_coverage.py)) |
+| Bundle | LOINC 2.82: `mirobody.BUNDLE_VERSION` → `loinc-2.82+2026.08.28-af2524b7a285` — release, cut date and a digest over the bundle's own members |
+| Install | `pip install mirobody` is **2 packages, 52 MB**, on numpy only |
 
-The release, the cut date, and a digest over the bundle's own members — so a
-build-time consumer of the vocabulary and a runtime `pip` pin can be asserted
-to be the same corpus, which the package version alone never told you.
-[LOINC's licence](https://loinc.org/license/) requires every copy to carry the
-version number; `res/fhir_loinc_bundle.NOTICE` does, and
-`scripts/stamp_bundle_version.py --check` keeps the stamp honest.
-
-**Why 2.82 and not 2.83.** The axis table and the 677k-row corpus are coupled
-through the folded `LONG_COMMON_NAME`, and 2.83 renamed 2,842 of them
-(`Cerebral spinal fluid` → `Cerebrospinal Fluid` and that family). Measured:
-upgrading the axis alone loses **3,486** name→code links and gains none, so a
-real upgrade means rebuilding the corpus — which spans SNOMED CT, RxNorm, CVX
-and DCM, each licensed separately and none redistributable here. The known
-cost of staying: 650 codes that 2.83 has marked DISCOURAGED or DEPRECATED are
-still answerable, which shows up as 52 of the 6,815 benchmark cases that
-resolve. Withholding them was measured too and not taken — LOINC offers a
-replacement for only 9 of the 658, so it would mostly turn a dated code into no
-code, and a reading with no code cannot be grouped at all.
-
-**LOINC covers more of the wearable world than people expect.** It is not only
-lab panels: `BDYWGT.*` codes body composition (`101685-6` body bone mass,
-`73964-9` body muscle mass, `101684-9` percentage of body water), `HRTRATE.*`
-distinguishes resting heart rate (`40443-4`) from a spot reading, and there are
-codes for step counts (`41950-7`), sleep stages (`93831-6` deep, `93830-8`
-light), HRV SDNN (`112429-6`), VO₂ peak and elevation climbed. Where it stops
-is vendor composites — Garmin's Body Battery and stress score have no code,
-correctly, because they are one company's formula rather than a measurement.
-
-**Coverage of a vocabulary is not the same as recall on it**, and the gap is
-ours, not LOINC's: `Body bone mass` resolves to `101685-6` here, while the
-Chinese `骨量` resolves to a dental volume code, because no alias routes it.
-That is what [`res/resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv)
-is for — a row written by a person beats a surface match in the index, every
-time.
-
-→ [loinc.org](https://loinc.org/) · [licence](https://loinc.org/license/) ·
-[release notes](https://loinc.org/kb/) · the download is free but requires an
-account, which is why the derived bundle ships and the source release does not.
-
-→ [Standardization](https://docs.mirobody.ai/en/api-reference/standardization/) ·
-[Architecture](https://docs.mirobody.ai/en/concepts/architecture/) ·
-[Data flow](https://docs.mirobody.ai/en/concepts/data-flow/)
-
----
+Why 2.82 and not 2.83, what LOINC covers of the wearable world, and the opt-in
+semantic tier that cannot abstain: → [Standardization in depth](docs/standardization.md)
 
 ## 📊 Benchmarks — open and independently reproducible
 
-Our health-AI benchmarks are the **most-downloaded in their category on Hugging
-Face** (4,000+ each):
-
-| Benchmark | What it measures | Downloads |
-| --- | --- | --- |
-| [ESL-Bench](https://huggingface.co/datasets/healthmemoryarena/ESL-Bench) | Event-driven longitudinal health agents — 100 synthetic users, 10,000 queries, programmatic ground truth ([arXiv:2604.02834](https://arxiv.org/abs/2604.02834)) | 4,800+ |
-| [MedHall-Bench](https://huggingface.co/datasets/healthmemoryarena/MedHall-Bench) | Medical hallucination | 4,500+ |
-| [MedHarm-Bench](https://huggingface.co/datasets/healthmemoryarena/MedHarm-Bench) | Harmful medical advice | 4,300+ |
-
-Reproduce any of them with one command via
-**[mirobody-eval](https://github.com/thetahealth/mirobody-eval)**, which also
-seeds a deployment with synthetic (PHI-free) trajectories.
-
----
+The most-downloaded health-AI benchmarks in their category on Hugging Face,
+4,000+ downloads a month each:
+[ESL-Bench](https://huggingface.co/datasets/mirobody/ESL-Bench) (event-driven
+longitudinal health agents — 100 synthetic users, 10,000 queries,
+[arXiv:2604.02834](https://arxiv.org/abs/2604.02834)) ·
+[MedHall-Bench](https://huggingface.co/datasets/mirobody/MedHall-Bench) (medical
+hallucination) · [MedHarm-Bench](https://huggingface.co/datasets/mirobody/MedHarm-Bench)
+(harmful medical advice). Reproduce any of them with one command via
+**[mirobody-eval](https://github.com/thetahealth/mirobody-eval)**, which also seeds
+a deployment with synthetic, PHI-free trajectories.
 
 ## 🚀 Run the whole thing
 
 ```bash
 git clone https://github.com/thetahealth/mirobody.git && cd mirobody
-git lfs install && git lfs pull   # the engine's data bundles; `resolve` needs them — `install` first, or a fresh clone holds pointer stubs
-./deploy.sh           # Postgres + pgvector, Redis, server, worker
+git lfs install && git lfs pull   # the engine's data bundles; a fresh clone holds pointer stubs until you do
+./deploy.sh                       # Postgres + pgvector, Redis, server, worker → http://localhost:18060
 ```
 
-Then open **http://localhost:18060**. The server prints the accounts it accepts
-at startup — the shipped one is `caregiver@mirobody.ai`, code `111111`, named for
-the role it plays: you sign in as the caregiver and the record you read belongs to
-someone else.
-
-No mail provider? You do not need one. The sign-in page opens on **password**,
-with email-code as a third tab:
+Sign in as `caregiver@mirobody.ai`, code `111111`. No mail provider needed: the
+sign-in page opens on password, and an account of your own is one request away:
 
 ```bash
 curl -X POST localhost:18060/password/register -H 'Content-Type: application/json' \
      -d '{"email":"you@example.com","password":"at-least-8-chars"}'
 ```
 
-**One key runs everything.** Set an [OpenRouter key](https://openrouter.ai/keys)
-in `OPENROUTER_API_KEY` — for the Docker stack that means the `.env` file next
-to `compose.yaml`, then `docker compose restart` (that alone suffices: the app
-re-reads `/app/.env`; a shell `export` does not reach the containers) — and
-conversation, vision file parsing and semantic
-indicator search are all live — chat via Claude/GPT/DeepSeek, embeddings via
-the open-weights Qwen3-Embedding-8B (self-hostable: serve the same model
-behind any OpenAI-compatible `/v1/embeddings` and point
-`OPENROUTER_BASE_URL` at it).
+**Your care circle.** The account is named for the role it plays: you sign in as
+the caregiver, and the record you read belongs to someone else. A circle is the
+unit of sharing — each member holds their own record and decides, on their own
+row, whether the others may view it.
 
-Indicator search embeds **your own indicator names**, not the LOINC corpus:
-the worker's `IndicatorSyncTask` writes `th_series_dim.embedding_qwen3_8b` on
-each ingest, and the query is matched against that. It needs `mirobody worker`
-running, which `./deploy.sh` starts. That is a different index from the
-downloadable-corpus matrix the second tier wants, and it is the one that comes
-for free.
+<div align="center">
+<img src="docs/images/your-care-circle.svg" alt="Your own thin record next to hers — the thick one you can only view." width="820">
+</div>
 
-If openrouter.ai is unreachable from your network (the case in mainland
-China), a [DashScope key](https://dashscope.console.aliyun.com/apiKey) in
-`DASHSCOPE_API_KEY` is a drop-in replacement — chat via Qwen (DeepSeek/Kimi
-one uncomment away), vision via qwen3-vl, embeddings via text-embedding-v4.
-
-No further configuration either way; direct provider keys (Google, OpenAI)
-remain supported — see `config.yaml`.
-→ [Docker deployment](https://docs.mirobody.ai/en/deployment/docker/) ·
-[Configuration](https://docs.mirobody.ai/en/configuration/) ·
-[Local Python setup](https://docs.mirobody.ai/en/development/setup/)
-
-### 👨‍👩‍👧 The whole engine, in four minutes
-
-`SEED_DEMO_DATA` defaults to on, so the ① → ② → ③ chain is walkable the moment
-`./deploy.sh` finishes — signing in and browsing the seeded record need no
-key; the upload extraction in part 2 and the questions after it ride the one
-key configured above. Four parts, each recorded against the running stack.
-
-**1 · Arrive.** You sign in owning a **thin** record — a few weeks of
-self-tracked vitals and one unremarkable checkup, seeded as your own — and find
-one synthetic person sharing a **thick** one with you: **Demo (synthetic)**,
-244 indicators and 14,273 readings across two years, five documents the agent
-can `read_file`. Same question, two records: *your* HbA1c answers with one
-boring-normal value from data you own; *hers* answers with a two-year story
-from data you can only view. Isolation you can see, not just read about.
+`SEED_DEMO_DATA` is on by default, so the circle is already populated: you own a
+**thin** record — a few weeks of self-tracked vitals and one unremarkable
+checkup — and one synthetic person shares a **thick** one with you,
+**Demo (synthetic)**: **244 indicators, 14,273 readings** across two years, five
+documents the agent can read. Same question, two records: *your* HbA1c answers
+with one boring-normal value from data you own; *hers* with a two-year story from
+data you can only view. The recording walks both sides — your own indicators and
+files, then the switch to her shared record and its two years of HbA1c:
 
 <p align="center">
   <img src="docs/images/care-circle-demo.gif"
        alt="Your own account's indicators and an uploaded report, then switching to Demo's shared record and opening two years of HbA1c" width="880">
 </p>
 
-<div align="center">
-<img src="docs/images/your-care-circle.svg" alt="Your own thin record next to hers — the thick one you can only view." width="820">
-</div>
-
 The switch in that diagram is a column, not a promise:
 `care_circle_members.health_access`, `NOT NULL DEFAULT 0`, on **your own** row.
 Being invited into a circle shares nothing — the member decides, and no other
-person's action can raise it. The check that reads it raises rather than
-returning a falsy value, so a route that forgets to look answers 403 instead of
-handing over a record.
-[`examples/06_care_circle_rules.py`](examples/06_care_circle_rules.py) prints
-the whole decision table offline.
+person's action can raise it. A route that forgets to check answers 403 instead of
+handing over a record. [`examples/06_care_circle_rules.py`](examples/06_care_circle_rules.py)
+prints the whole decision table offline. Set `SEED_DEMO_DATA=false` for a
+deployment that will hold real data.
 
-**2 · ③ Answers, on someone else's record.** Ask about her HbA1c and the agent
-finds the data itself, cross-references the lab draws against the sensor-derived
-series, and charts both — then tells you the improvement did not hold.
+**One key runs everything.** Browsing the seeded record needs no key; the upload
+and the questions below ride one. We recommend an OpenAI-compatible endpoint: an
+[OpenAI key](https://platform.openai.com/api-keys) in `OPENAI_API_KEY`, an
+[OpenRouter key](https://openrouter.ai/keys) in `OPENROUTER_API_KEY`, or any
+compatible gateway reached with `<PROVIDER>_BASE_URL` and `<PROVIDER>_MODEL`.
+Put it in the `.env` next to `compose.yaml`, then `docker compose restart` — that
+alone suffices, the app re-reads `/app/.env`; a shell `export` does not reach the
+containers. Pick a **multimodal model**: report photos and scanned pages are read
+through the vision path (`<PROVIDER>_VISION_MODEL`), and a text-only model leaves
+them unparsed. Other direct keys are listed in `config.yaml`.
 
-<p align="center">
-  <img src="docs/images/ask-circle-demo.gif"
-       alt="Asking about the shared record's HbA1c; the agent queries, charts lab and sensor series together, and reads the trend" width="880">
-</p>
-
-```
-lab-drawn HbA1c   7.2 % (2024-04)  →  6.5 % (2024-10)  →  6.6 % (2025-04)
-                  only 3 lab draws in two years — the sensor eA1C has 104
-```
-
-**3 · ① Collect + ② Standardize, on your own.**
-`demo/lab_report_2025-10-15.pdf` is a panel deliberately held out of the
-seed, so uploading it is not a no-op. Drop it on the Data page and twelve
-analytes come out with their values and units in seconds, each linking back to
-the page it was read from.
+**① Collect + ② Translate.** Drop [`demo/lab_report_2025-10-15.pdf`](demo/lab_report_2025-10-15.pdf)
+on the Data page and twelve analytes come out with values and units, each
+linking back to the page it was read from:
 
 <p align="center">
   <img src="docs/images/upload-demo.gif"
        alt="Dropping a lab-report PDF on the Data page; twelve analytes extracted, each linked to its source file" width="880">
 </p>
 
-**4 · ③ Answers, on what you just uploaded.** Ask again, now about your own
-record. The agent reads the report through the virtual filesystem, flags all
-twelve results against their printed reference ranges — and says plainly that one
-date is not a trend.
+**③ Answer (agent).** Ask about her HbA1c and the agent finds the data, charts
+the three lab draws against 104 sensor-derived estimates, and says plainly that
+the improvement did not hold. Ask again about the report you just uploaded and it
+reads that instead — the fourth scene of
+[the four-minute walkthrough](docs/walkthrough.md).
 
 <p align="center">
-  <img src="docs/images/ask-own-demo.gif"
-       alt="Asking about your own just-uploaded panel; the agent reads the report and flags every result against its reference range" width="880">
+  <img src="docs/images/ask-circle-demo.gif"
+       alt="Asking about the shared record's HbA1c; the agent queries, charts lab and sensor series together, and reads the trend" width="880">
 </p>
 
-That contrast is the demo's point: **two years of history buys a trend, one panel
-buys an interpretation.** Both answers cite what they read.
+→ [Docker deployment](https://docs.mirobody.ai/en/deployment/docker/) ·
+[Configuration](https://docs.mirobody.ai/en/configuration/) ·
+[Local Python setup](https://docs.mirobody.ai/en/development/setup/)
 
-Every value is synthetic — generated for ESL-Bench by
-[mirobody-eval](https://github.com/thetahealth/mirobody-eval) and vendored, so the
-seed needs no network and no key. Set `SEED_DEMO_DATA=false` for a deployment that
-will hold real data. What the extraction pass does *not* yet do with those twelve
-readings is written down in [docs/roadmap.md](docs/roadmap.md) rather than glossed
-over here.
+## 🔌 Use it, extend it
 
----
-
-## 🧩 Extend it
-
-Four directory keys point at plugin roots; drop a file in and restart — or
-`pip install` a package that declares a `mirobody.providers` / `mirobody.tools`
-/ `mirobody.agents` entry point. Tools become both agent tools and MCP tools
-with no extra wiring.
-
-| You want | Drop it in | Docs |
+| You want | Do this | Docs |
 | --- | --- | --- |
-| A new tool | `mirobody/agent/tools/` | [Adding tools](https://docs.mirobody.ai/en/tools/adding-tools/) |
-| An Agent Skill (SKILL.md) | `mirobody/agent/skills/` | [Skills](https://docs.mirobody.ai/en/tools/skills/) |
-| Your own agent harness | `AGENT_DIRS` → your directory (replaces the shipped agent) | [`mirobody/agent/README.md`](mirobody/agent/README.md) |
-| A device provider | `mirobody/pulse/providers/` | [Provider integration](https://docs.mirobody.ai/en/development/provider-integration/) |
-| These tools in Claude Desktop, Cursor, or your own agent loop | Settings → MCP (your personal `/mcp` URL) | [MCP servers](https://docs.mirobody.ai/en/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](examples/07_claude_agent_sdk.py) |
-
-Every tool the agent has is also served over MCP at `/mcp`, gated per user.
-→ [Built-in tools](https://docs.mirobody.ai/en/tools/built-in/) ·
-[MCP servers](https://docs.mirobody.ai/en/api-reference/mcp-servers/)
-
----
-
-## 🔌 Use it from your own code
-
-| Surface | For | Docs |
-| --- | --- | --- |
-| `pip install mirobody` | Offline resolution and units — 2 packages, no key, no network | [Engine](https://docs.mirobody.ai/en/engine/) |
-| `pip install 'mirobody[parse]'` | The above, plus turning a document into readings — PDF, image, Excel, Word, PowerPoint, text; a born-digital report needs a text model key only, and only a scanned page reaches a vision model | [Engine](https://docs.mirobody.ai/en/engine/) |
-| `pip install 'mirobody[agent]'` | The deepagents harness as a library — middleware, virtual-filesystem backends, checkpointer, model clients — for an agent you run yourself | [Bringing your own agent](CONTRIBUTING.md#-bringing-your-own-agent) |
-| `mirobody.bundle` | Build-time: the LOINC axis table and alias sources, for generating a seed or corpus | [`mirobody/bundle.py`](mirobody/bundle.py) |
-| HTTP API | Your app talking to a deployment | [API overview](https://docs.mirobody.ai/en/api-reference/overview/) · [Data](https://docs.mirobody.ai/en/api-reference/data/) |
-| MCP | Claude, Cursor, or any MCP client reading a user's record | [MCP servers](https://docs.mirobody.ai/en/api-reference/mcp-servers/) |
-| Backbone mode | Your own agent, our data layer | [Backbone](https://docs.mirobody.ai/en/api-reference/backbone-mode/) |
-
-Not sure which? → [Choose your API](https://docs.mirobody.ai/en/api-reference/choose-your-api/)
-
----
-
-## 🏗️ Repository layout
-
-```
-mirobody/
-├── engine.py    the front door — resolve() and parse_file()
-├── units/       UCUM units, unit_family, conversions          ┐ the library:
-├── lexical.py   surface folding + the CJK-aware tokenizer     │ numpy only,
-├── bundle.py    build-time: the axis table and alias sources    │
-├── res/         the shipped LOINC bundles, res/metrics.tsv       │
-├── kernel/      what health data MEANS, as pure functions:       │
-│                metrics · series · quality · overlay · meds ·    │
-│                query · tools · ops · connect · sink · events ·  │
-│                evidence · memory · vendors/                     ┘ 2 packages
-├── documents/   a file becomes text, by kind — PDF text layer, OCR for scanned pages only, Office, text   [parse]
-├── pulse/       ① Collect     — providers, file parsing, store, aggregate, read (Postgres)
-├── indicator/   ② Standardize — resolver internals, concept graph, bundle build
-├── agent/       ③ Answers     — the agent: models/ fs/ wire/ middleware/ tools/ chat/
-├── mcp/         the MCP server
-├── server/      the HTTP application — routers, auth, the bundled web client
-├── utils/       mechanisms a consumer binds: config, db, sse, net, llm_output, prompts, log
-├── user/        identity and the care circle — who may read whose record
-└── schema/      the DDL, replayed at boot in dev
-
-demo/            the care-circle demo fixture, beside frontend/ — a checkout
-frontend/        the bundled web client                          has them, a
-                                                                 pip install
-                                                                 does not
-```
-
-**Two forms, and they want opposite things.** The PyPI package is a LIBRARY and
-is meant to be small enough that nobody has to think about it: `pip install
-mirobody` is **2 packages, 52 MB** — the entries above the `documents/` line, on numpy.
-`[parse]` adds document reading, `[agent]` the harness as a library; `[app]` is everything, and the only thing that
-installs it is `requirements.txt`, because the Docker application is
-`git clone && ./deploy.sh` and never a pip install.
-
-**Machine-enforced, not documented:** four import-linter contracts hold the
-lines — the library layer imports nothing but numpy, and the engine never
-imports the agent layer — and `lint-imports` fails the build. A separate gate, `scripts/check_wheel_data.py`, keeps the bundle-build passes and the
-v2 semantic pipeline — 19,000 lines nobody who installs the package can run —
-out of the artifact.
-
-→ [Architecture](https://docs.mirobody.ai/en/concepts/architecture/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
-
----
-
-## 📚 Documentation
-
-For full documentation, see **[docs.mirobody.ai](https://docs.mirobody.ai/)**
-(English and Simplified Chinese).
-
-| | |
-| --- | --- |
-| [Quickstart](https://docs.mirobody.ai/en/quickstart/) · [Installation](https://docs.mirobody.ai/en/installation/) · [Self-host](https://docs.mirobody.ai/en/self-host/) | Getting it running |
-| [Indicators](https://docs.mirobody.ai/en/concepts/indicators/) · [Providers](https://docs.mirobody.ai/en/concepts/providers/) · [File processing](https://docs.mirobody.ai/en/concepts/file-processing/) | How the three stages work |
-| [API reference](https://docs.mirobody.ai/en/api-reference/) · [Streaming](https://docs.mirobody.ai/en/api-reference/streaming/) · [Function calling](https://docs.mirobody.ai/en/api-reference/function-calling/) | Building against it |
-| [Contributing](https://docs.mirobody.ai/en/development/contributing/) · [Setup](https://docs.mirobody.ai/en/development/setup/) | Working on it |
-
-### In-repo, for contributors
-
-Each package carries a `README.md` saying what it is; long-form guides live in
-[`docs/`](docs/). All of it is English, whichever README you arrived from.
-
-| | Where |
-| --- | --- |
-| Runnable examples | [`examples/`](examples/README.md) |
-| The kernel | [`kernel/`](mirobody/kernel/__init__.py) — the stage → module map · [pipeline](docs/pipeline.md) — eleven stages, ten invariants |
-| ① Collect | [`pulse/`](mirobody/pulse/README.md) · [providers](mirobody/pulse/providers/README.md) · [aggregation](mirobody/pulse/aggregate/README.md) · [Apple Health](mirobody/pulse/apple/README.md) |
-| ① guides | [connect a wearable](docs/provider-setup.md) · [write a provider](docs/provider-guide.md) · [file processing](docs/file-processing.md) · [`documents/`](mirobody/documents/__init__.py) · [Apple Health API](docs/apple-health.md) |
-| ② Standardize | [`indicator/`](mirobody/indicator/README.md) · [indicators & units](mirobody/pulse/standardize/README.md) |
-| ③ Answers | [`agent/`](mirobody/agent/README.md) · [tools](mirobody/agent/tools/README.md) · [the one data tool](docs/answers.md) · [medications](docs/medications.md) |
-| Plumbing | [configuration](mirobody/utils/config/README.md) · [database schema](mirobody/schema/README.md) · [the web client](docs/frontend.md) · [backup & restore](docs/backup-restore.md) |
-| Working on it | [CONTRIBUTING.md](CONTRIBUTING.md) · [AGENTS.md](AGENTS.md) · [testing](docs/testing.md) · [aggregator script](docs/aggregation-tests.md) · [roadmap](docs/roadmap.md) · [CHANGELOG](CHANGELOG.md) · [SECURITY](SECURITY.md) |
-
----
+| Offline resolution and units in your code | `pip install mirobody` — 2 packages, no key, no network | [Engine](https://docs.mirobody.ai/en/engine/) |
+| A document turned into readings | `pip install 'mirobody[parse]'` — PDF, image, Excel, Word, PowerPoint, text; only a scanned page reaches a vision model | [Engine](https://docs.mirobody.ai/en/engine/) |
+| The agent harness as a library | `pip install 'mirobody[agent]'` — middleware, virtual-filesystem backends, checkpointer | [Bringing your own agent](CONTRIBUTING.md#-bringing-your-own-agent) |
+| These tools in Claude Desktop, Cursor or your own loop | Settings → MCP: every agent tool is also served at `/mcp`, gated per user | [MCP servers](https://docs.mirobody.ai/en/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](examples/07_claude_agent_sdk.py) |
+| Your app talking to a deployment | HTTP API, or backbone mode: your agent, our data layer | [API overview](https://docs.mirobody.ai/en/api-reference/overview/) · [Backbone](https://docs.mirobody.ai/en/api-reference/backbone-mode/) |
+| A new tool, skill or device provider | Drop a file into `mirobody/agent/tools/`, `mirobody/agent/skills/` or `mirobody/pulse/providers/` and restart — or `pip install` a package declaring a `mirobody.providers` / `mirobody.tools` / `mirobody.agents` entry point | [Adding tools](https://docs.mirobody.ai/en/tools/adding-tools/) · [Skills](https://docs.mirobody.ai/en/tools/skills/) · [Providers](https://docs.mirobody.ai/en/development/provider-integration/) |
+| Your own agent harness | `AGENT_DIRS` → your directory replaces the shipped agent | [`mirobody/agent/README.md`](mirobody/agent/README.md) |
+| The LOINC axis table and alias sources at build time | `mirobody.bundle` — for generating a seed or a corpus | [`mirobody/bundle.py`](mirobody/bundle.py) |
 
 ## 🤝 Contributing
 
 The highest-leverage contribution is a term the resolver gets wrong. Run
-`mirobody resolve "<term>"`, and if the answer is wrong or empty add a row to
-[`resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv) plus a case to
-[`test_engine_coverage.py`](mirobody/test_engine_coverage.py) — the coverage score
-is the review.
+`mirobody resolve "<term>"`; if the answer is wrong or empty,
+[report it](https://github.com/thetahealth/mirobody/issues/new?template=wrong-term.yml)
+or add a row to [`resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv) plus a
+case to [`test_engine_coverage.py`](mirobody/test_engine_coverage.py) — the
+coverage score is the review.
 
 ```bash
 pip install -e '.[test]' && pytest -q && lint-imports
 ```
 
-→ [Contributing guide](https://docs.mirobody.ai/en/development/contributing/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
+→ [CONTRIBUTING.md](CONTRIBUTING.md) · [Contributing guide](https://docs.mirobody.ai/en/development/contributing/) ·
+[Repository layout](docs/repository-layout.md) · [Roadmap](docs/roadmap.md) · [CHANGELOG](CHANGELOG.md) · [SECURITY](SECURITY.md)
 
----
+## 📚 Documentation
+
+**[docs.mirobody.ai](https://docs.mirobody.ai/)**, in English and Chinese — start at the
+[Quickstart](https://docs.mirobody.ai/en/quickstart/), or go straight to the
+[API reference](https://docs.mirobody.ai/en/api-reference/). Long-form guides for
+contributors live in [`docs/`](docs/README.md).
 
 ## 🙏 Acknowledgements
 
-Mirobody standardizes health data and reasons over it; it does not try to be
-the best way to connect a device. Projects that shaped the kernel's rules —
-none of their code is included here:
-
-- **[Open Wearables](https://github.com/the-momentum/open-wearables)** (MIT,
-  © 2025 Momentum) — a self-hosted wearable integration platform with twelve
-  provider connectors and mobile SDKs. Its data-standardization write-up
-  enumerates the failure modes (daily totals summed with their own samples,
-  offset-only day boundaries, silent unit assumptions, read-time election)
-  that `mirobody.kernel.series`, `mirobody.kernel.quality` and `res/metrics.tsv` exist to
-  close. If you need the connectors, run Open Wearables and point a mirobody
-  decoder at its `/timeseries` API.
-- **[Home Assistant](https://github.com/home-assistant/core)** — the
-  `state_class` idea behind the indicator catalogue.
-- **[Open mHealth](https://github.com/openmhealth/schemas) / IEEE 1752** —
-  the `effective_*` / `modality` field names on a fact.
-- **[wearipedia](https://github.com/Stanford-Health/wearipedia)** — seeded
-  synthetic vendor payloads instead of real people's data.
-- **[dlt](https://github.com/dlt-hub/dlt), [Airbyte](https://github.com/airbytehq/airbyte-python-cdk),
-  [Singer](https://github.com/meltano/sdk)** — write dispositions and the
-  check / discover / read shape of a connector.
-- **[deepagents](https://github.com/langchain-ai/deepagents), LangChain,
-  [langchain-quickjs](https://github.com/langchain-ai/langchain-quickjs)** —
-  the agent harness, the file-system projection and the `eval` REPL.
-- **Regenstrief Institute (LOINC), UCUM, HL7 FHIR, OHDSI OMOP** — the code
-  systems and resource shapes the catalogue and the medication model are
-  anchored to; see `LICENSE-3RD-PARTY`.
+Projects that shaped the kernel's rules — none of their code is included here:
+[Open Wearables](https://github.com/the-momentum/open-wearables) (the
+data-standardization failure modes `kernel/series` and `kernel/quality` close),
+[Home Assistant](https://github.com/home-assistant/core) (`state_class`),
+[Open mHealth](https://github.com/openmhealth/schemas) / IEEE 1752 (field names),
+[wearipedia](https://github.com/Stanford-Health/wearipedia) (synthetic payloads),
+[dlt](https://github.com/dlt-hub/dlt) / [Airbyte](https://github.com/airbytehq/airbyte-python-cdk) / [Singer](https://github.com/meltano/sdk) (connector shape),
+[deepagents](https://github.com/langchain-ai/deepagents), LangChain and [langchain-quickjs](https://github.com/langchain-ai/langchain-quickjs) (the harness, the file-system projection, the `eval` REPL),
+Regenstrief Institute (LOINC), UCUM, HL7 FHIR, OHDSI OMOP — see `LICENSE-3RD-PARTY`.
 
 ## ⭐ Star History
 
@@ -493,13 +257,10 @@ none of their code is included here:
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
   </picture>
 </a>
-</div>
 
----
+*If it read a report for you, a star helps the next person find it.*
 
-<div align="center">
-
-**[📚 Docs](https://docs.mirobody.ai/)** · **[💬 Chat](https://chat.mirobody.ai/)** · **[🔌 Platform](https://platform.mirobody.ai/)** · **[🧪 Eval](https://github.com/thetahealth/mirobody-eval)**
+**[📚 Docs](https://docs.mirobody.ai/)** · **[▶ Demo](https://chat.mirobody.ai/)** · **[🔌 Platform](https://platform.mirobody.ai/)** · **[🧪 Eval](https://github.com/thetahealth/mirobody-eval)**
 
 Apache 2.0 · © 2026 [Theta Health](https://thetahealth.ai)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,43 +1,30 @@
 <div align="center">
 
-# 🚀 Mirobody
+# Mirobody
 
-**AI 原生的健康数据引擎——收集、标准化，并针对检验报告、穿戴设备与基因数据进行推理。**
+**AI 原生的健康数据引擎 —— 收集 · 转译 · 回答（Collect · Translate · Answer）。**
 
-已上线的消费级健康产品 **Theta Wellness** 由 Mirobody 驱动——注册用户 5,000+，日活 500+。
+体检报告、穿戴设备与基因数据，统一成 AI 能读懂的同一种语言：LOINC 编码、UCUM
+单位、FHIR 就绪。解析器离线可用；引擎驱动着已上线的消费级健康产品
+**[Theta Wellness](https://www.thetahealth.ai/)**——注册用户 5,000+，日活 500+。
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)
-[![Benchmarks](https://img.shields.io/badge/%F0%9F%A4%97_Benchmarks-4k%2B_downloads_each-FFD21E.svg)](https://huggingface.co/healthmemoryarena)
+[![Benchmarks](https://img.shields.io/badge/%F0%9F%A4%97_Benchmarks-4k%2B_downloads_each-FFD21E.svg)](https://huggingface.co/mirobody)
 [![arXiv](https://img.shields.io/badge/arXiv-2604.02834-b31b1b.svg)](https://arxiv.org/abs/2604.02834)
 [![Docs](https://img.shields.io/badge/Docs-docs.mirobody.ai-black)](https://docs.mirobody.ai/)
+[![GitHub stars](https://img.shields.io/github/stars/thetahealth/mirobody?style=social)](https://github.com/thetahealth/mirobody/stargazers)
 
-**[📚 文档](https://docs.mirobody.ai/)** · **[💬 云端聊天服务——chat.mirobody.ai](https://chat.mirobody.ai/)** · **[🔌 API 平台——platform.mirobody.ai](https://platform.mirobody.ai/)**
+**[📚 文档](https://docs.mirobody.ai/zh/)** · **[▶ 在线演示](https://chat.mirobody.ai/)** · **[🔌 API 平台](https://platform.mirobody.ai/)**
 
-**[English](README.md)** · **简体中文** · **[繁體中文](README.zh-TW.md)** · **[日本語](README.ja.md)**
-
-*血液检验、穿戴设备、基因数据、影像资料——全都零散破碎，彼此互不兼容。
-在 AI 能够真正理解你的健康状况之前，必须先将这些信号统一为 AI
-可直接读取的标准格式。这正是本引擎的职责。*
-
-<img src="docs/images/where-your-data-comes-from.zh-CN.svg" alt="从穿戴设备到饭菜照片 —— 一种标准格式，AI 可直接读取。" width="920">
+**[English](README.md)** · **中文**
 
 </div>
 
-本引擎完成三件事，整个代码库（包括「贡献」一节）也严格按照这三个阶段组织——与[在线文档](https://docs.mirobody.ai/zh/api-reference/)采用同一套 **C · S · A** 体系：
+## ⚡ 60 秒试一下
 
-| 阶段 | 含义 | 位置 |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **① 收集** | 接入数据信号：3 家设备提供者 + 1 个 SQL 数据源 · 7 种文件格式 · Apple Health（只接收：由已签名的 iOS 客户端推送进来） | [`pulse/`](mirobody/pulse/) |
-| **② 标准化** | 将任意一条读数解析为标准代码（LOINC · SNOMED CT · RxNorm），统一单位，落入 FHIR 认可的码制 | [`indicator/`](mirobody/indicator/) |
-| **③ 解答** | 推理：agent 通过虚拟文件系统读取*原始文件*，以图表和引用来源作答 | [`agent/`](mirobody/agent/) |
-
----
-
-## ⚡ 60 秒快速体验
-
-指标解析是本引擎的入口能力，无需 key、无需配置、无需联网：
+不需要 key、不需要配置、不需要联网：
 
 ```bash
 pip install mirobody
@@ -49,392 +36,204 @@ mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖
        alt="mirobody resolve：四种语言落到同一个 LOINC 码，完全离线" width="880">
 </p>
 
-> 以上为真实输出，且 GIF 本身是构建产物——由 [`scripts/make_demo_gifs.py`](scripts/make_demo_gifs.py)
-> 渲染 [`docs/demo/resolve.html`](docs/demo/resolve.html) 生成，因此演示内容始终与命令的实际行为保持同步。
+`血红蛋白` 和 `ヘモグロビン` 与 `hemoglobin` 落到同一个码 LOINC `718-7`，`空腹血糖(GLU)`
+落到空腹血糖。`血脂` 是一个类别而不是一项观测，解析器主动留空，而不是给一个看起来合理的错码。
 
 ```python
 from mirobody.engine import resolve, resolve_reading
 
 resolve("血红蛋白").loinc                                # '718-7'   任何语言，同一个码
-resolve("total cholesterol").loinc                     # '2093-3'  [质量/体积]
-resolve_reading("total cholesterol", "5.0", "mmol/L")   # '14647-2' [摩尔/体积]
-resolve_reading("total cholesterol", "193", "mg/dL")    # '2093-3'  单位决定了码
+resolve("total cholesterol").loinc                     # '2093-3'  [Mass/volume]
+resolve_reading("total cholesterol", "5.0", "mmol/L")   # '14647-2' [Moles/volume]
+resolve_reading("total cholesterol", "193", "mg/dL")    # '2093-3'  单位决定码
 
 resolve("中性粒细胞百分比").loinc                          # '26511-6' 中性粒细胞/白细胞
 resolve_reading("中性粒细胞", "62 %", None).loinc          # '26511-6' 百分比……
-resolve_reading("中性粒细胞", "4.2", "10*9/L").loinc       # '26499-4' ……与绝对值是两个码
-resolve("血脂").resolved                                 # False    这是类别，不是一次观测
+resolve_reading("中性粒细胞", "4.2", "10*9/L").loinc       # '26499-4' ……和计数是两个码
+resolve("血脂").resolved                                 # False    类别，不是观测项
 ```
 
-**如有数值和单位，请一并传入。** LOINC 将单位**与**结果类型编入代码身份，因此同一
-名称会解析到不同的码——将 mmol/L 的结果归入 mg/dL 的码下，正是同一序列混入两种
-单位的常见根源。`resolve` 的策略是宁可弃答也不猜测：空串 `""` 表示留待人工确认，
-`"refused"` 本身即是明确的答案。
-→ [引擎参考](https://docs.mirobody.ai/zh/engine/) ·
-[指标](https://docs.mirobody.ai/zh/concepts/indicators/)
+**有数值和单位就一起传。** LOINC 把单位和结果类型编进了标识本身，同一个名字
+会因单位不同而落到不同的码。`resolve` 宁可留空也不猜：空码是一个值得再看一眼的缺口，
+`method="refused"` 则是一个明确的决定。
+→ [引擎参考](https://docs.mirobody.ai/zh/engine/) · [指标](https://docs.mirobody.ai/zh/concepts/indicators/)
 
----
+## 为什么是 Mirobody
 
-## 标准化层的能力
+- **两份报告，同一个指标，写法和单位都不一样。** 这就是问题本身。Mirobody 把任何语言
+  的任何读数转译成 LOINC + UCUM，遇到不认识的词就明确留空，不硬猜。
+- **AI 只能在它读得懂的数据上推理。** agent 读的是原始文件，把化验值和传感器序列画
+  在一张图上，并标出它读的是哪一页。
+- **自托管、基于标准、Apache-2.0。** 一条 `./deploy.sh` 在你自己的机器上跑起整套系统；
+  产出的是 LOINC 编码、FHIR 就绪、随时可以带走的记录，同一组工具也通过 MCP 提供给
+  Claude Desktop、Cursor 或你自己的 agent。
 
-标准化层并非简单的对照查表，而是一套完整的术语归一体系：
+## 收集 · 转译 · 回答
 
-- **概念图谱**：440,961 个节点 · 22,044,110 条跨词表边 · **595,746 个来源 id**
-  蒸馏成标准概念（LOINC · SNOMED CT · RxNorm 桥接）。
-- **49,253 个多语言别名**（中文 22,578 · 日本語 16,809 · 另 5 种：de·es·fr·ko·ru）。
-  `hemoglobin`、`血红蛋白`、`血紅素`、`ヘモグロビン` 全部落到 LOINC 718-7。
-- **繁体中文按两个独立问题分别处理。** 字形折叠是机械转换（内置 3,336 字的
-  zh-Hant → zh-Hans 对照表）；词汇差异则不是——台湾地区临床用词不同，直接折叠
-  `血紅素` 会得到 HbA1c 的码。此类词汇按繁体拼写单独收录，收录条目的优先级始终
-  高于机械折叠。
-- **单位**归一到约 310 个 UCUM 家族，含量纲分析、按 LOINC 码索引的摩尔质量桥接，
-  以及对 `%` 与 `10*9/L` 的明确拒绝。305 个标准 pulse 指标。
-- **第二层语义召回，刻意保持可选。** 以上均为词法层能力，遇到未收录词汇即弃答——
-  这是明确的能力边界。余弦召回（[`indicator/semantic.py`](mirobody/indicator/semantic.py)）
-  可以越过该边界，但**它无法弃答**：面对从未见过的词汇，它会以与正确答案相同的置信度
-  返回最近邻，任何阈值都无法区分二者。**仓库不含向量矩阵，也没有可下载的现成版本**：
-  它是 108,248 条 LOINC 行 × 1024 维（约 221 MB），且与 (provider, model) 一一绑定，
-  需用 `scripts/build_loinc_embeddings.py` 针对你配置的 embedding 模型自行构建。换成
-  另一个模型的矩阵不会报错——它会在错误的向量空间里自信地排序，所以构建时会写出
-  `<matrix>.meta.json`，加载时校验不符即拒绝。在你把 `MIROBODY_SEMANTIC_INDEX` 指向
-  一个矩阵之前 `resolve()` 完全不受影响；指向之后，也只用于*建议*一个待人工确认的码，
-  绝不直接写入标准码。
-  → [语义召回](https://docs.mirobody.ai/zh/concepts/semantic-recall/)：基准数字、两道轴向
-  闸门，以及为什么 `min_score` 不是正确性阈值。
-- **上述能力经过量化验证，而非单方声明。**
-  [`test_engine_coverage.py`](mirobody/test_engine_coverage.py) 以真实体检套组、
-  按检验报告的实际书写形式为离线解析器打分，覆盖英文、简体中文、繁体中文、日文，
-  以及可穿戴平台 API 的词汇。**当前 211/211；该测试初版时为 32/94。** 其评判标准为
-  **临床**正确性：将 `血红蛋白` 解析为 HbA1c 的码计为失败，`血脂` 则必须解析为空。
+<p align="center">
+  <img src="docs/images/where-your-data-comes-from.zh-CN.svg" alt="从穿戴设备到饭菜照片 —— 一种标准格式，AI 可直接读取。" width="920">
+</p>
 
-```bash
-pytest mirobody/test_engine_coverage.py -s   # 离线，约一秒
-```
+引擎只做三件事，代码库、文档和[贡献指南](#-贡献)都严格按这三个阶段组织：
 
-### 用的是哪一版 LOINC,它覆盖什么、不覆盖什么
-
-随包分发的语料切自 **LOINC 2.82**,而且这件事由运行时报出,不是写在一句会漂的注释里:
-
-```python
->>> import mirobody; mirobody.BUNDLE_VERSION
-'loinc-2.82+2026.08.28-af2524b7a285'
-```
-
-版本、切分日期,加上一段对语料成员本身算出的摘要——所以「构建期消费这份词表」和
-「运行时 pin 的这个包」是不是同一份语料,可以被断言;光看包版本永远看不出来。
-[LOINC 许可](https://loinc.org/license/)要求每一份拷贝都带上版本号,
-`res/fhir_loinc_bundle.NOTICE` 带了,`scripts/stamp_bundle_version.py --check` 保证它不撒谎。
-
-**为什么是 2.82 而不是 2.83。** axis 表与那 677k 行语料是通过折叠后的
-`LONG_COMMON_NAME` 绑在一起的,而 2.83 系统性改名了其中 2,842 条
-(`Cerebral spinal fluid` → `Cerebrospinal Fluid` 这一类)。实测:只升 axis 会丢
-**3,486** 条「语料名 → 码」的连接,且新增为零。真要升就得连语料一起重建——那份语料
-横跨 SNOMED CT、RxNorm、CVX、DCM,各自单独授权,都不可在此再分发。留在 2.82 的
-已知代价:650 个被 2.83 标为 DISCOURAGED / DEPRECATED 的码仍可被答出,反映到基准上
-是 6,815 条能解析的案例里的 52 条。「干脆拒答这些码」也量过,没有采纳——658 个里
-LOINC 只为 9 个给出了替代码,拒答基本等于把「一个有点旧但正确的码」变成「没有码」,
-而没有码的读数根本无法归组。
-
-**LOINC 对可穿戴领域的覆盖比多数人以为的宽。** 它不只是化验套餐:`BDYWGT.*` 编身体成分
-(`101685-6` 骨量、`73964-9` 肌肉量、`101684-9` 体水分率),`HRTRATE.*` 把静息心率
-(`40443-4`)与单次测量区分开,另有步数(`41950-7`)、睡眠分期(`93831-6` 深睡、
-`93830-8` 浅睡)、HRV SDNN(`112429-6`)、VO₂ peak、爬升高度等码。它停在厂商复合指标上
-——Garmin 的身体电量与压力分数没有码,而这是对的:那是一家公司的算法,不是一个测量。
-
-**覆盖不等于召回,而且这道差距是我们的、不是 LOINC 的**:`Body bone mass` 在这里能解析到
-`101685-6`,中文的 `骨量` 却落到一个牙科体积码上,因为没有别名把它路由过去。
-这正是 [`res/resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv) 存在的理由
-——一行由人写下的意图,永远赢过索引里的表面匹配。
-
-→ [loinc.org](https://loinc.org/) · [许可](https://loinc.org/license/) ·
-[发布说明](https://loinc.org/kb/) · 下载免费,但需要注册账号并同意条款,
-这也是随包分发派生语料、而不分发原始发布的原因。
-
-→ [标准化](https://docs.mirobody.ai/zh/api-reference/standardization/) ·
-[架构](https://docs.mirobody.ai/zh/concepts/architecture/) ·
-[数据流](https://docs.mirobody.ai/zh/concepts/data-flow/)
-
----
-
-## 📊 基准——评测全部开源，可独立复现
-
-本项目的健康 AI 基准在 Hugging Face 同类数据集中**下载量最高**（各 4,000+）：
-
-| 基准 | 测什么 | 下载量 |
+| 阶段 | 含义 | 位置 |
 | --- | --- | --- |
-| [ESL-Bench](https://huggingface.co/datasets/healthmemoryarena/ESL-Bench) | 事件驱动的纵向健康 agent——100 个合成用户、10,000 个问题、程序化标准答案（[arXiv:2604.02834](https://arxiv.org/abs/2604.02834)） | 4,800+ |
-| [MedHall-Bench](https://huggingface.co/datasets/healthmemoryarena/MedHall-Bench) | 医疗幻觉 | 4,500+ |
-| [MedHarm-Bench](https://huggingface.co/datasets/healthmemoryarena/MedHarm-Bench) | 有害医疗建议 | 4,300+ |
+| **① 收集 Collect** | 接入数据：3 家设备提供者 + 1 个 SQL 数据源 · 7 种文件格式 · Apple Health（只接收：由已签名的 iOS 客户端推送进来） | [`pulse/`](mirobody/pulse/) |
+| **② 转译 Translate**（standardize） | 一套标准：把任意读数解析为标准编码（LOINC · SNOMED CT · RxNorm），单位统一到 UCUM，落入 FHIR 认可的码制 | [`indicator/`](mirobody/indicator/) |
+| **③ 回答 Answer**（agent） | 推理：agent 通过虚拟文件系统读取*原始文件*，以图表和引用来源作答 | [`agent/`](mirobody/agent/) |
 
-任一基准均可通过 **[mirobody-eval](https://github.com/thetahealth/mirobody-eval)**
-一条命令复现；该工具同时可为部署预置合成（不含 PHI）的健康轨迹数据。
+## 用数字说话
 
----
+| | |
+| --- | --- |
+| 概念图谱 | 440,961 个节点 · 22,044,110 条跨词表边 · 595,746 个来源 ID，蒸馏为标准概念（LOINC · SNOMED CT · RxNorm 桥接） |
+| 别名 | 49,253 条多语言别名（中文 22,578 · 日本語 16,809 · 另有 de·es·fr·ko·ru）；`hemoglobin`、`血红蛋白`、`血紅素`、`ヘモグロビン` 都落到 718-7 |
+| 繁体中文 | 内置 3,336 字的繁→简折叠表，加上按繁体拼写单独维护的词条——人工词条永远优先于折叠 |
+| 单位 | 约 310 个 UCUM 单位族，带量纲分析和按 LOINC 码索引的摩尔质量桥；305 个标准 pulse 指标 |
+| 覆盖率 | **211/211**：一份普通体检会印出来的各类面板，按报告的原始写法，覆盖英文、中文（简繁）和日文（[`test_engine_coverage.py`](mirobody/test_engine_coverage.py)） |
+| 词表版本 | LOINC 2.82：`mirobody.BUNDLE_VERSION` → `loinc-2.82+2026.08.28-af2524b7a285`——版本号、切割日期和词表成员的摘要 |
+| 安装体积 | `pip install mirobody` 只有 **2 个包、52 MB**，仅依赖 numpy |
 
-## 🚀 完整部署
+为什么停在 2.82 而不升 2.83、LOINC 对穿戴指标的覆盖、以及那个可选但不会主动留空的
+语义层：→ [标准化详解](docs/standardization.md)
+
+## 📊 基准——公开、可独立复现
+
+Hugging Face 上同类下载量最高的健康 AI 基准，每个月各 4,000+ 次下载：
+[ESL-Bench](https://huggingface.co/datasets/mirobody/ESL-Bench)（事件驱动的纵向健康
+agent 评测——100 个合成用户、10,000 个问题，[arXiv:2604.02834](https://arxiv.org/abs/2604.02834)）·
+[MedHall-Bench](https://huggingface.co/datasets/mirobody/MedHall-Bench)（医学幻觉）·
+[MedHarm-Bench](https://huggingface.co/datasets/mirobody/MedHarm-Bench)（有害医疗建议）。
+用 **[mirobody-eval](https://github.com/thetahealth/mirobody-eval)** 一条命令复现任何一个，
+它还能给部署注入合成的、不含 PHI 的轨迹数据。
+
+## 🚀 跑起整套系统
 
 ```bash
 git clone https://github.com/thetahealth/mirobody.git && cd mirobody
-git lfs install && git lfs pull   # 引擎的数据包，`resolve` 需要它；先 `install`，否则新克隆里只有 LFS 指针
-./deploy.sh           # Postgres + pgvector、Redis、服务、worker
+git lfs install && git lfs pull   # 引擎的数据包；不执行的话新克隆里只有 LFS 指针
+./deploy.sh                       # Postgres + pgvector、Redis、服务、worker → http://localhost:18060
 ```
 
-随后打开 **http://localhost:18060**。服务启动时会打印可用的登录账号——内置账号为
-`caregiver@mirobody.ai`，验证码 `111111`。账号名即角色：你以照护者（caregiver）
-身份登录，查看他人共享的记录。
-
-无需邮件服务。登录页默认为**密码**方式，邮箱验证码为第三个标签页：
+用 `caregiver@mirobody.ai`、验证码 `111111` 登录。不需要邮件服务：登录页默认是密码登录，
+一条请求就能创建你自己的账号：
 
 ```bash
 curl -X POST localhost:18060/password/register -H 'Content-Type: application/json' \
      -d '{"email":"you@example.com","password":"at-least-8-chars"}'
 ```
 
-**一把 key 即可启用全部能力。** 将 [OpenRouter key](https://openrouter.ai/keys)
-配置为 `OPENROUTER_API_KEY`——Docker 部署下即写入 `compose.yaml` 旁的 `.env`
-文件并 `docker compose restart`（重启即可生效：应用会重读 `/app/.env`；shell 里
-`export` 不会传入容器）——对话、文件视觉解析、指标语义搜索即全部就绪——对话
-使用 Claude/GPT/DeepSeek，语义搜索使用开源权重的 Qwen3-Embedding-8B（支持自主
-部署：以任何 OpenAI 兼容的 `/v1/embeddings` 服务部署同一模型，并将
-`OPENROUTER_BASE_URL` 指向该服务即可）。
+**你的关爱圈。** 账号名就是角色：你以照护者身份登录，看到的记录属于另一个人。关爱圈是
+共享的单位——每个成员各自持有自己的记录，并在自己那一行上决定圈里其他人能不能看。
 
-指标搜索编码的是**你自己的指标名**，不是 LOINC 全表：worker 的
-`IndicatorSyncTask` 在每次 ingest 后写入 `th_series_dim.embedding_qwen3_8b`，
-查询即与之比对。它需要 `mirobody worker` 在跑，`./deploy.sh` 会一并启动。
-这与上文第二层要的那份「可下载的全表矩阵」是两个不同的索引，而这一个是白送的。
+<div align="center">
+<img src="docs/images/your-care-circle.zh-CN.svg" alt="你自己薄薄的一份，旁边是她厚厚的一份——后者你只能查看。" width="820">
+</div>
 
-若所在网络无法访问 openrouter.ai（中国大陆境内即属此情形），可将
-[DashScope（阿里云百炼）key](https://dashscope.console.aliyun.com/apiKey) 配置为
-`DASHSCOPE_API_KEY` 作为等价替代——对话使用 Qwen（取消对应注释即可启用
-DeepSeek/Kimi），视觉解析使用 qwen3-vl，语义搜索使用 text-embedding-v4，所有
-模型 id 均经线上端点实测验证。如 PyPI 官方源缓慢，可为 pip 配置国内镜像
-（Docker 部署可直接 `PIP_INDEX_URL=<镜像地址> ./deploy.sh`）。
-
-两条路径均无需额外配置；各厂商的直连 key（Google、OpenAI）同样受支持——详见
-`config.yaml`。
-→ [Docker 部署](https://docs.mirobody.ai/zh/deployment/docker/) ·
-[配置](https://docs.mirobody.ai/zh/configuration/) ·
-[本地 Python 环境](https://docs.mirobody.ai/zh/development/setup/)
-
-### 👨‍👩‍👧 四分钟走一遍整个引擎
-
-`SEED_DEMO_DATA` 默认开启，`./deploy.sh` 完成后即可完整走通 ① → ② → ③ 全链路——
-登录与浏览种子数据无需任何 key；第 2 步的上传抽取与其后的提问共用上文配置的那
-一把 key。以下四段演示均录制自真实运行的服务。
-
-**1 · 登录。** 登录后你名下已有一份**轻量**记录——数周的自测体征与一次结果正常的
-年度体检；同时，关爱圈中已有一位合成用户向你共享了一份**完整**记录：
-**Demo (synthetic)**，两年跨度、244 个指标、14,273 条读数，以及五份 agent 可通过
-`read_file` 读取的文档。同一个问题对应两份相互独立的记录：查询*你自己*的 HbA1c，
-答案是你名下的一条正常值；查询*她*的，答案来自一份你仅有查看权限的两年记录。
-数据隔离由此直接可见。
+`SEED_DEMO_DATA` 默认开启，所以圈子一开始就不是空的：你名下有一份**薄**记录——数周的
+自测体征和一次结果正常的年度体检——同时一位合成人物向你共享了一份**厚**记录：
+**Demo (synthetic)**，两年跨度、**244 个指标、14,273 条读数**、五份 agent 能读的文件。
+同一个问题，两份记录：问*你自己*的糖化血红蛋白，答案是你名下一条平平无奇的正常值；
+问*她*的，答案来自一份你只有查看权限的两年记录。下面的录屏把两边都走了一遍：先是你
+自己的指标和文件，再切到她共享的记录，打开两年的糖化血红蛋白：
 
 <p align="center">
   <img src="docs/images/care-circle-demo.zh-CN.gif"
        alt="自己账号的指标与上传文件，切换到 Demo 的共享记录，打开两年的 HbA1c" width="880">
 </p>
 
-<div align="center">
-<img src="docs/images/your-care-circle.zh-CN.svg" alt="你自己薄薄的一份，旁边是她厚厚的一份——后者你只能查看。" width="820">
-</div>
+图里那个开关是一个数据库列，不是一句承诺：`care_circle_members.health_access`，
+`NOT NULL DEFAULT 0`，落在**你自己**那一行上。被邀请进圈子不共享任何东西——由成员自己决定，
+别人的任何操作都抬不高它。忘了检查的路由会回 403，而不是把记录交出去。
+[`examples/06_care_circle_rules.py`](examples/06_care_circle_rules.py) 能离线打印整张决策表。
+要保存真实数据时，设 `SEED_DEMO_DATA=false`。
 
-她的 HbA1c 是最该先打开的一条序列——因为它改善过，然后没保住：
+**一把 key 跑通全部。** 浏览种子记录不需要 key；下面的上传和提问需要一把。我们推荐走
+OpenAI 兼容的接入方式：把 [OpenAI key](https://platform.openai.com/api-keys) 写进 `OPENAI_API_KEY`，
+或把 [OpenRouter key](https://openrouter.ai/keys) 写进 `OPENROUTER_API_KEY`，或者用
+`<PROVIDER>_BASE_URL` 和 `<PROVIDER>_MODEL` 指向任何兼容的网关。写进 `compose.yaml` 旁边的
+`.env`，然后 `docker compose restart`——这一步就够了，应用会重新读取 `/app/.env`；shell 里的
+`export` 到不了容器。请选**多模态模型**：报告照片和扫描页走的是视觉通道
+（`<PROVIDER>_VISION_MODEL`），纯文本模型解析不了它们。其他直连 key 见 `config.yaml`。
 
-```
-2024-04-16   7.2 %
-2024-10-15   6.5
-2025-04-15   6.6      ← 之后就没有了
-```
-
-**问它。** 用中文问她这两年的糖化血红蛋白怎么变化，agent 自己去找数据：化验室只有
-**2 条**直接检测，而传感器推算的 eA1C 有 **88 条**，它把两者画在同一张图上，用 GMI
-交叉验证，然后告诉你这两年一直贴着 6.5% 的临界值窄幅波动——没有明显趋势。它也主动
-说了自己的局限：只有两次化验，CGM 推算与化验不是一回事。
-
-<p align="center">
-  <img src="docs/images/ask-circle-demo.zh-CN.gif"
-       alt="用中文询问共享记录的 HbA1c；agent 查询、把化验值与传感器序列画在一起、读出趋势" width="880">
-</p>
-
-**接着给它一个文件。** `demo/lab_report_2025-10-15.pdf` 是她**下一次**的
-面板，刻意从灌入数据里留出，所以上传它不是空操作。拖到 Data 页，① 收集 和 ② 标准化
-在几秒内跑完：十二个分析物带着数值和单位出来，每一个都能点回它被读出来的那一页。
+**① 收集 + ② 转译。** 把 [`demo/lab_report_2025-10-15.pdf`](demo/lab_report_2025-10-15.pdf)
+拖到 Data 页，十二个分析物连同数值和单位被抽出来，每一个都链回它所在的那一页：
 
 <p align="center">
   <img src="docs/images/upload-demo.zh-CN.gif"
        alt="把化验单 PDF 拖到 Data 页；十二个分析物被抽取出来，每一个都链回它的原文件" width="880">
 </p>
 
-**再问它一次，这次是你自己刚上传的那份。** 同一个 agent，换一份数据：它读那份报告
-本身，把每个结果对照参考区间标出来。
+**③ 回答（agent）。** 问她的糖化血红蛋白，agent 自己找到数据，把三次化验值和 104 个传感器
+估算值画在一起，然后直说：那次改善没有保持住。再问一遍你刚上传的那份报告，它读的就换成
+那一份——这是[四分钟完整演示](docs/walkthrough.md)的第四幕。
 
 <p align="center">
-  <img src="docs/images/ask-own-demo.zh-CN.gif"
-       alt="询问你自己刚上传的面板；agent 读报告本身，把每个结果对照参考区间标出来" width="880">
+  <img src="docs/images/ask-circle-demo.zh-CN.gif"
+       alt="用中文询问共享记录的 HbA1c；agent 查询、把化验值与传感器序列画在一起、读出趋势" width="880">
 </p>
 
-这个对比就是这段演示的用意：**两年历史买到的是趋势，一份面板买到的是解读。**两个回答
-都会引用自己读到的东西。
+→ [Docker 部署](https://docs.mirobody.ai/zh/deployment/docker/) ·
+[配置](https://docs.mirobody.ai/zh/configuration/) ·
+[本地 Python 环境](https://docs.mirobody.ai/zh/development/setup/)
 
-所有数值都是合成的——由 [mirobody-eval](https://github.com/thetahealth/mirobody-eval)
-为 ESL-Bench 生成后固化在仓里，所以灌数据不需要联网、不需要 key。要让部署承载真实
-数据，把 `SEED_DEMO_DATA` 设为 false。抽取这一步对那十二条读数**还做不到**什么，写在
-[docs/roadmap.md](docs/roadmap.md) 里，而不是在这里含糊过去。
+## 🔌 用它，扩展它
 
----
-
-## 🧩 扩展
-
-四个目录配置键分别指向插件根目录；放入文件并重启即可生效，或者 `pip install` 一个声明了
-`mirobody.providers` / `mirobody.tools` / `mirobody.agents` entry point 的包。新增工具会同时注册为
-agent 工具与 MCP 工具，无需额外接线。
-
-| 扩展目标 | 放入位置 | 文档 |
+| 你想要 | 这样做 | 文档 |
 | --- | --- | --- |
-| 新增工具 | `mirobody/agent/tools/` | [添加工具](https://docs.mirobody.ai/zh/tools/adding-tools/) |
-| Agent Skill（SKILL.md） | `mirobody/agent/skills/` | [Skills](https://docs.mirobody.ai/zh/tools/skills/) |
-| 自己的 agent harness | `AGENT_DIRS` → 你的目录（替换自带 agent） | [`mirobody/agent/README.md`](mirobody/agent/README.md) |
-| 设备 provider | `mirobody/pulse/providers/` | [Provider 接入](https://docs.mirobody.ai/zh/development/provider-integration/) |
-| 在 Claude Desktop、Cursor 或你自己的 agent 循环里用这些工具 | Settings → MCP（你的个人 `/mcp` URL） | [MCP 服务](https://docs.mirobody.ai/zh/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](examples/07_claude_agent_sdk.py) |
-
-agent 的每个工具同时通过 `/mcp` 对外提供，并按用户进行访问门控。
-→ [内置工具](https://docs.mirobody.ai/zh/tools/built-in/) ·
-[MCP 服务](https://docs.mirobody.ai/zh/api-reference/mcp-servers/)
-
----
-
-## 🔌 编程接入
-
-| 接口 | 适合 | 文档 |
-| --- | --- | --- |
-| `pip install mirobody` | 离线的指标解析与单位换算 —— 2 个包，无需 key，无需网络 | [引擎](https://docs.mirobody.ai/zh/engine/) |
-| `pip install 'mirobody[parse]'` | 在上一行之上，把文档变成读数 —— PDF、图片、Excel、Word、PowerPoint、文本；原生电子版报告只需一个文本模型的 key，只有扫描页才会送到视觉模型 | [引擎](https://docs.mirobody.ai/zh/engine/) |
-| `pip install 'mirobody[agent]'` | 把 deepagents harness 当库用 —— 中间件、虚拟文件系统后端、checkpointer、模型客户端 —— 装进你自己跑的 agent | [自带 agent](CONTRIBUTING.md#-bringing-your-own-agent) |
-| `mirobody.bundle` | 构建期：LOINC 轴表与别名源，用于生成种子或语料 | [`mirobody/bundle.py`](mirobody/bundle.py) |
-| HTTP API | 将你的应用对接到一个部署实例 | [API 总览](https://docs.mirobody.ai/zh/api-reference/overview/) · [数据](https://docs.mirobody.ai/zh/api-reference/data/) |
-| MCP | Claude、Cursor 或任何 MCP 客户端读取用户记录 | [MCP 服务](https://docs.mirobody.ai/zh/api-reference/mcp-servers/) |
-| Backbone 模式 | 你的 agent，配合本项目的数据层 | [Backbone](https://docs.mirobody.ai/zh/api-reference/backbone-mode/) |
-
-接口选型参考：[如何选择 API](https://docs.mirobody.ai/zh/api-reference/choose-your-api/)
-
----
-
-## 🏗️ 仓库结构
-
-```
-mirobody/
-├── engine.py    正门 —— resolve() 与 parse_file()
-├── units/       UCUM 单位、unit_family、换算            ┐ 库的部分：
-├── lexical.py   表层折叠 + CJK 感知分词器                │ 只依赖 numpy，
-├── bundle.py    构建期：轴表与别名源                        │
-├── res/         随包分发的 LOINC 语料、res/metrics.tsv     │
-├── kernel/      健康数据的“含义”，全是纯函数：              │
-│                metrics · series · quality · overlay · meds ·  │
-│                query · tools · ops · connect · sink · events · │
-│                evidence · memory · vendors/                    ┘ 共 2 个包
-├── documents/   文件按类型变成文本：PDF 文本层、只对扫描页 OCR、Office、纯文本   [parse]
-├── pulse/       ① 收集     —— provider、文件解析、存储、聚合（Postgres）
-├── indicator/   ② 标准化   —— 解析器内部、概念图、语料构建
-├── agent/       ③ 回答     —— agent：models/ fs/ wire/ middleware/ tools/ chat/
-├── mcp/         MCP 服务
-├── server/      HTTP 应用 —— 路由、鉴权、随包的 web 客户端
-├── utils/       消费方绑定的机制：config、db、sse、net、llm_output、prompts、log
-├── user/        身份与关爱圈 —— 谁可以读谁的记录
-└── schema/      DDL，开发环境启动时重放
-
-demo/            关爱圈演示数据，和 frontend/ 并排 —— 二者都只在源码检出里，
-frontend/        随包分发的 web 客户端    pip 安装的库不需要它们
-```
-
-**两种形态，诉求正好相反。** PyPI 包是**库**，小到不必让人想起它：
-`pip install mirobody` 是 **2 个包、52 MB** —— `documents/` 那一行以上的各项，外加 numpy。
-`[parse]` 加上读文档的能力，`[agent]` 把 harness 当库用；`[app]` 是全部，而唯一安装它的是 `requirements.txt`
-—— Docker 应用是 `git clone && ./deploy.sh`，从来不是 pip 安装出来的。
-
-**由工具强制执行，而非写在文档里**：四条 import-linter 契约守住这两条线——库层除
-numpy 外不导入任何东西，引擎永不导入 agent 层——违反即 `lint-imports` 构建失败。另一道闸门 `scripts/check_wheel_data.py`
-把语料构建流程与 v2 语义管线——19,000 行装了也跑不了的代码——挡在产物之外。
-
-→ [架构](https://docs.mirobody.ai/zh/concepts/architecture/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
-
----
-
-## 📚 文档
-
-更多细节请参考 **[docs.mirobody.ai](https://docs.mirobody.ai/)** 在线文档
-（英文与简体中文）。
-
-| | |
-| --- | --- |
-| [快速开始](https://docs.mirobody.ai/zh/quickstart/) · [安装](https://docs.mirobody.ai/zh/installation/) · [自托管](https://docs.mirobody.ai/zh/self-host/) | 快速上手 |
-| [指标](https://docs.mirobody.ai/zh/concepts/indicators/) · [Provider](https://docs.mirobody.ai/zh/concepts/providers/) · [文件处理](https://docs.mirobody.ai/zh/concepts/file-processing/) | 三个阶段的工作原理 |
-| [API 参考](https://docs.mirobody.ai/zh/api-reference/) · [流式](https://docs.mirobody.ai/zh/api-reference/streaming/) · [函数调用](https://docs.mirobody.ai/zh/api-reference/function-calling/) | 接口开发 |
-| [贡献](https://docs.mirobody.ai/zh/development/contributing/) · [环境搭建](https://docs.mirobody.ai/zh/development/setup/) | 参与开发 |
-
-### 仓库内文档（面向贡献者）
-
-每个包均附带 `README.md` 说明其职责；较长的专题指南位于 [`docs/`](docs/)。
-以下文档均为英文。
-
-| | Where |
-| --- | --- |
-| 可运行示例 | [`examples/`](examples/README.md) |
-| 内核 | [`kernel/`](mirobody/kernel/__init__.py) —— 阶段 → 模块对照 · [pipeline](docs/pipeline.md) —— 十一个阶段、十条不变量 |
-| ① 收集 | [`pulse/`](mirobody/pulse/README.md) · [providers](mirobody/pulse/providers/README.md) · [aggregation](mirobody/pulse/aggregate/README.md) · [Apple Health](mirobody/pulse/apple/README.md) |
-| ① 指南 | [connect a wearable](docs/provider-setup.md) · [write a provider](docs/provider-guide.md) · [file processing](docs/file-processing.md) · [`documents/`](mirobody/documents/__init__.py) · [Apple Health API](docs/apple-health.md) |
-| ② 标准化 | [`indicator/`](mirobody/indicator/README.md) · [indicators & units](mirobody/pulse/standardize/README.md) |
-| ③ 回答 | [`agent/`](mirobody/agent/README.md) · [tools](mirobody/agent/tools/README.md) · [the one data tool](docs/answers.md) · [medications](docs/medications.md) |
-| 底层设施 | [configuration](mirobody/utils/config/README.md) · [database schema](mirobody/schema/README.md) · [the web client](docs/frontend.md) · [backup & restore](docs/backup-restore.md) |
-| 参与开发 | [CONTRIBUTING.md](CONTRIBUTING.md) · [AGENTS.md](AGENTS.md) · [testing](docs/testing.md) · [aggregator script](docs/aggregation-tests.md) · [roadmap](docs/roadmap.md) · [CHANGELOG](CHANGELOG.md) · [SECURITY](SECURITY.md) |
-
----
+| 在自己的代码里离线解析与换算单位 | `pip install mirobody`——2 个包，无 key，无网络 | [引擎](https://docs.mirobody.ai/zh/engine/) |
+| 把一份文件变成读数 | `pip install 'mirobody[parse]'`——PDF、图片、Excel、Word、PowerPoint、文本；只有扫描页才会送到视觉模型 | [引擎](https://docs.mirobody.ai/zh/engine/) |
+| 把 agent 框架当库用 | `pip install 'mirobody[agent]'`——中间件、虚拟文件系统后端、checkpointer | [接入你自己的 agent](CONTRIBUTING.md#-bringing-your-own-agent) |
+| 在 Claude Desktop、Cursor 或你自己的循环里用这些工具 | 设置 → MCP：每个 agent 工具同时通过 `/mcp` 提供，按用户鉴权 | [MCP 服务](https://docs.mirobody.ai/zh/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](examples/07_claude_agent_sdk.py) |
+| 你的应用对接一个部署 | HTTP API，或 backbone 模式：你的 agent，我们的数据层 | [API 概览](https://docs.mirobody.ai/zh/api-reference/overview/) · [Backbone](https://docs.mirobody.ai/zh/api-reference/backbone-mode/) |
+| 新工具、新技能或新设备提供者 | 把文件放进 `mirobody/agent/tools/`、`mirobody/agent/skills/` 或 `mirobody/pulse/providers/` 然后重启——或者 `pip install` 一个声明了 `mirobody.providers` / `mirobody.tools` / `mirobody.agents` 入口点的包 | [添加工具](https://docs.mirobody.ai/zh/tools/adding-tools/) · [技能](https://docs.mirobody.ai/zh/tools/skills/) · [提供者](https://docs.mirobody.ai/zh/development/provider-integration/) |
+| 换掉整个 agent | `AGENT_DIRS` → 你的目录替换内置 agent | [`mirobody/agent/README.md`](mirobody/agent/README.md) |
+| 构建期拿 LOINC 轴表和别名来源 | `mirobody.bundle`——用来生成种子或语料 | [`mirobody/bundle.py`](mirobody/bundle.py) |
 
 ## 🤝 贡献
 
-最有价值的贡献是修正解析器解析错误的词条。运行 `mirobody resolve "<词>"`，若结果
-错误或为空，请在 [`resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv)
-中添加对应词条，并在 [`test_engine_coverage.py`](mirobody/test_engine_coverage.py)
-中补充测试用例——覆盖率测试即是评审标准。
+最高杠杆的贡献是一个解析错了的词。运行 `mirobody resolve "<那个词>"`，结果不对或为空，
+就[报一个](https://github.com/thetahealth/mirobody/issues/new?template=wrong-term.yml)，
+或者往 [`resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv) 加一行、往
+[`test_engine_coverage.py`](mirobody/test_engine_coverage.py) 加一个用例——覆盖率分数就是评审。
 
 ```bash
 pip install -e '.[test]' && pytest -q && lint-imports
 ```
 
-→ [贡献指南](https://docs.mirobody.ai/zh/development/contributing/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
+→ [CONTRIBUTING.md](CONTRIBUTING.md) · [贡献指南](https://docs.mirobody.ai/zh/development/contributing/) ·
+[仓库结构](docs/repository-layout.md) · [路线图](docs/roadmap.md) · [CHANGELOG](CHANGELOG.md) · [SECURITY](SECURITY.md)
 
----
+## 📚 文档
+
+**[docs.mirobody.ai](https://docs.mirobody.ai/zh/)**，中英双语——从[快速开始](https://docs.mirobody.ai/zh/quickstart/)进入，
+或直接看 [API 参考](https://docs.mirobody.ai/zh/api-reference/)。面向贡献者的长篇指南在 [`docs/`](docs/README.md)。
 
 ## 🙏 致谢
 
-mirobody 做的是健康数据的标准化与推理，不追求成为接入设备的最佳方式。以下项目塑造了内核的规则——本仓不包含它们的任何代码：
+塑造了内核规则的项目——这里不包含它们的任何代码：
+[Open Wearables](https://github.com/the-momentum/open-wearables)（`kernel/series` 与 `kernel/quality` 所封堵的那些数据标准化失效模式）、
+[Home Assistant](https://github.com/home-assistant/core)（`state_class`）、
+[Open mHealth](https://github.com/openmhealth/schemas) / IEEE 1752（字段命名）、
+[wearipedia](https://github.com/Stanford-Health/wearipedia)（合成设备数据）、
+[dlt](https://github.com/dlt-hub/dlt) / [Airbyte](https://github.com/airbytehq/airbyte-python-cdk) / [Singer](https://github.com/meltano/sdk)（连接器形态）、
+[deepagents](https://github.com/langchain-ai/deepagents)、LangChain 与 [langchain-quickjs](https://github.com/langchain-ai/langchain-quickjs)（agent 框架、文件系统投影、`eval` REPL）、
+Regenstrief Institute（LOINC）、UCUM、HL7 FHIR、OHDSI OMOP——见 `LICENSE-3RD-PARTY`。
 
-- **[Open Wearables](https://github.com/the-momentum/open-wearables)**（MIT，© 2025 Momentum）——自托管的可穿戴设备接入平台，十二家厂商连接器与移动端 SDK。它的数据标准化文档列出的失败模式（日总量与自身明细相加、只有偏移没有时区的日界、静默的单位假设、读时择源），正是 `mirobody.kernel.series`、`mirobody.kernel.quality` 与 `res/metrics.tsv` 要关掉的洞。需要设备连接器时，请运行 Open Wearables，再用 mirobody 的解码器接它的 `/timeseries` API。
-- **[Home Assistant](https://github.com/home-assistant/core)**——指标目录里 `state_class` 的思想来源。
-- **[Open mHealth](https://github.com/openmhealth/schemas) / IEEE 1752**——事实上的 `effective_*` / `modality` 字段命名。
-- **[wearipedia](https://github.com/Stanford-Health/wearipedia)**——用带种子的合成厂商载荷代替真人数据。
-- **[dlt](https://github.com/dlt-hub/dlt)、[Airbyte](https://github.com/airbytehq/airbyte-python-cdk)、[Singer](https://github.com/meltano/sdk)**——写入语义与连接器的 check / discover / read 三段形态。
-- **[deepagents](https://github.com/langchain-ai/deepagents)、LangChain、[langchain-quickjs](https://github.com/langchain-ai/langchain-quickjs)**——agent 运行时、文件系统投影与 `eval` REPL。
-- **Regenstrief Institute（LOINC）、UCUM、HL7 FHIR、OHDSI OMOP**——目录与用药模型所锚定的编码系统与资源形状；见 `LICENSE-3RD-PARTY`。
-
-## ⭐ Star 趋势
+## ⭐ Star 历史
 
 <div align="center">
 <a href="https://www.star-history.com/#thetahealth/mirobody&Date">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date&theme=dark" />
     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
-    <img alt="Star 趋势图" src="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=thetahealth/mirobody&type=Date" />
   </picture>
 </a>
-</div>
 
----
+*如果它帮你读懂了一份报告，一个 star 能让下一个人找到它。*
 
-<div align="center">
-
-**[📚 文档](https://docs.mirobody.ai/)** · **[💬 Chat](https://chat.mirobody.ai/)** · **[🔌 平台](https://platform.mirobody.ai/)** · **[🧪 Eval](https://github.com/thetahealth/mirobody-eval)**
+**[📚 文档](https://docs.mirobody.ai/zh/)** · **[▶ 演示](https://chat.mirobody.ai/)** · **[🔌 平台](https://platform.mirobody.ai/)** · **[🧪 评测](https://github.com/thetahealth/mirobody-eval)**
 
 Apache 2.0 · © 2026 [Theta Health](https://thetahealth.ai)
 

--- a/archived/README.ja.md
+++ b/archived/README.ja.md
@@ -6,8 +6,8 @@
 
 稼働中のコンシューマー向け健康プロダクト **Theta Wellness** は、Mirobody の上で動いている ―― 登録ユーザー 5,000+、DAU 500+。
 
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](../pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)
 [![Benchmarks](https://img.shields.io/badge/%F0%9F%A4%97_Benchmarks-4k%2B_downloads_each-FFD21E.svg)](https://huggingface.co/healthmemoryarena)
 [![arXiv](https://img.shields.io/badge/arXiv-2604.02834-b31b1b.svg)](https://arxiv.org/abs/2604.02834)
@@ -15,13 +15,13 @@
 
 **[📚 ドキュメント](https://docs.mirobody.ai/)** · **[💬 ホスト型チャット — chat.mirobody.ai](https://chat.mirobody.ai/)** · **[🔌 APIプラットフォーム — platform.mirobody.ai](https://platform.mirobody.ai/)**
 
-**[English](README.md)** · **[简体中文](README.zh-CN.md)** · **[繁體中文](README.zh-TW.md)** · **日本語**
+**[English](../README.md)** · **[简体中文](../README.zh-CN.md)** · **[繁體中文](README.zh-TW.md)** · **日本語**
 
 *血液検査、ウェアラブル、ゲノム、画像診断 ―― どれも断片化していて、互換性がない。
 AIが健康データを理解する前に、まずこれらの信号を統合し、AIが実際に読める単一の標準に
 落とし込む必要がある。それがこのエンジンの仕事である。*
 
-<img src="docs/images/where-your-data-comes-from.ja.svg" alt="ウェアラブルから食事の写真まで —— ひとつの標準形式に、AI が読める形で。" width="920">
+<img src="../docs/images/where-your-data-comes-from.ja.svg" alt="ウェアラブルから食事の写真まで —— ひとつの標準形式に、AI が読める形で。" width="920">
 
 </div>
 
@@ -29,9 +29,9 @@ AIが健康データを理解する前に、まずこれらの信号を統合し
 
 | 段階                | 意味                                                                                                     | 場所                                                   |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| **① Collect(収集)** | 信号を取り込む:デバイスプロバイダ3種 + SQLソース・ファイル形式7種・Apple Health(受信のみ:署名済みiOSクライアントから送信) | [`pulse/`](mirobody/pulse/) |
-| **② Standardize(標準化)**    | 単一標準への統一:任意の測定値を正規コード(LOINC・SNOMED CT・RxNorm)に解決し、単位を正規化し、FHIRが認めるコード体系に載せる | [`indicator/`](mirobody/indicator/)                    |
-| **③ Answers(応答)**  | 推論:エージェントが仮想ファイルシステム経由で*元の文書*を読み、グラフと引用付きで回答     | [`agent/`](mirobody/agent/)                  |
+| **① Collect(収集)** | 信号を取り込む:デバイスプロバイダ3種 + SQLソース・ファイル形式7種・Apple Health(受信のみ:署名済みiOSクライアントから送信) | [`pulse/`](../mirobody/pulse/) |
+| **② Standardize(標準化)**    | 単一標準への統一:任意の測定値を正規コード(LOINC・SNOMED CT・RxNorm)に解決し、単位を正規化し、FHIRが認めるコード体系に載せる | [`indicator/`](../mirobody/indicator/)                    |
+| **③ Answers(応答)**  | 推論:エージェントが仮想ファイルシステム経由で*元の文書*を読み、グラフと引用付きで回答     | [`agent/`](../mirobody/agent/)                  |
 
 ---
 
@@ -45,11 +45,11 @@ mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖
 ```
 
 <p align="center">
-  <img src="docs/images/resolve-demo.ja.gif"
+  <img src="../docs/images/resolve-demo.ja.gif"
        alt="mirobody resolve：4つの言語が1つのLOINCコードに落ちる、完全オフライン" width="880">
 </p>
 
-> これは実際の出力で、GIFはビルド成果物だ ―― [`docs/demo/resolve.html`](docs/demo/resolve.html) を [`scripts/make_demo_gifs.py`](scripts/make_demo_gifs.py) が描画するので、示すと主張しているコマンドから離れていくことがない。
+> これは実際の出力で、GIFはビルド成果物だ ―― [`docs/demo/resolve.html`](../docs/demo/resolve.html) を [`scripts/make_demo_gifs.py`](../scripts/make_demo_gifs.py) が描画するので、示すと主張しているコマンドから離れていくことがない。
 
 ```python
 from mirobody.engine import resolve, resolve_reading
@@ -90,7 +90,7 @@ resolve("血脂").resolved                                 # False    観測で�
 - **単位**は約310のUCUMファミリーへ正規化。次元解析、LOINCコードをキーとするモル質量
   ブリッジ、`%` と `10*9/L` に対する明示的な拒否を含む。標準pulse指標305種。
 - **第2の層があり、意図的にオプトインのままだ。** 上のすべては語彙的で、知らない用語には
-  棄権する ―― 正直な天井だ。コサイン検索([`indicator/semantic.py`](mirobody/indicator/semantic.py))
+  棄権する ―― 正直な天井だ。コサイン検索([`indicator/semantic.py`](../mirobody/indicator/semantic.py))
   はそれを越えるが、**棄権できない**：見たことのない用語に対して、正解と同じ確信度で最近傍を
   返し、両者を分けるしきい値は存在しない。**行列は同梱せず、配布もしていない**: LOINC
   108,248行 × 1024次元(約221 MB)で、(provider, model)の組に固有なので、
@@ -102,7 +102,7 @@ resolve("血脂").resolved                                 # False    観測で�
   → [セマンティック検索](https://docs.mirobody.ai/en/concepts/semantic-recall/)：ベンチマーク、
   2つの軸ゲート、そして `min_score` が正しさのしきい値ではない理由。
 - **この主張は断言ではなく計測している。**
-  [`test_engine_coverage.py`](mirobody/test_engine_coverage.py) は健診が実際に出す
+  [`test_engine_coverage.py`](../mirobody/test_engine_coverage.py) は健診が実際に出す
   パネルでオフラインリゾルバを採点する。報告書が実際に印字する書き方で、英語・
   简体中文・繁體中文・日本語、さらにプラットフォームAPIが教えるウェアラブル語彙も。
   **今日は211/211。書いた日は32/94だった。** 採点するのは*臨床的*正しさで、
@@ -151,7 +151,7 @@ GarminのBody Batteryやストレススコアにコードは無く、それは�
 **カバレッジと再現率は別物で、その差はLOINC側ではなくこちら側にある**:
 `Body bone mass` はここで `101685-6` に解決するのに、日本語・中国語の `骨量` は
 歯科の体積コードに落ちる。そこへ導くエイリアスが無いからだ。
-[`res/resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv) はそのためにある ――
+[`res/resolver_overrides.tsv`](../mirobody/res/resolver_overrides.tsv) はそのためにある ――
 人が書き下ろした一行は、索引の表層一致に常に勝つ。
 
 → [loinc.org](https://loinc.org/) · [ライセンス](https://loinc.org/license/) ·
@@ -242,12 +242,12 @@ text-embedding-v4。
 2年分の記録から回答が返る。データ分離がそのまま画面上で確認できる。
 
 <p align="center">
-  <img src="docs/images/care-circle-demo.ja.gif"
+  <img src="../docs/images/care-circle-demo.ja.gif"
        alt="自分のアカウントの指標とアップロードした文書、Demoの共有記録へ切り替え、2年分のHbA1cを開く" width="880">
 </p>
 
 <div align="center">
-<img src="docs/images/your-care-circle.ja.svg" alt="自分の薄い記録の隣に、彼女の厚い記録 ―― 後者は閲覧のみ。" width="820">
+<img src="../docs/images/your-care-circle.ja.svg" alt="自分の薄い記録の隣に、彼女の厚い記録 ―― 後者は閲覧のみ。" width="820">
 </div>
 
 最初に開くべき系列は彼女のHbA1cだ ―― 良くなって、そのあと保たなかった:
@@ -264,7 +264,7 @@ text-embedding-v4。
 限界も自分から言う ―― 検査は2回しかなく、CGM推定と検査値は同じものではない。
 
 <p align="center">
-  <img src="docs/images/ask-circle-demo.ja.gif"
+  <img src="../docs/images/ask-circle-demo.ja.gif"
        alt="日本語で共有された記録のHbA1cを尋ねる。エージェントが照会し、検査値とセンサー系列を重ねて描き、傾向を読む" width="880">
 </p>
 
@@ -274,7 +274,7 @@ Dataページに落とせば ① Collect と ② Standardize が数秒で走り�
 伴って出てくる。どれも読み取り元のページに戻れる。
 
 <p align="center">
-  <img src="docs/images/upload-demo.ja.gif"
+  <img src="../docs/images/upload-demo.ja.gif"
        alt="検査報告のPDFをDataページに落とす。12項目が抽出され、どれも元ファイルにリンクする" width="880">
 </p>
 
@@ -284,7 +284,7 @@ Dataページに落とせば ① Collect と ② Standardize が数秒で走り�
 はっきり言う。
 
 <p align="center">
-  <img src="docs/images/ask-own-demo.ja.gif"
+  <img src="../docs/images/ask-own-demo.ja.gif"
        alt="自分がアップロードしたパネルを尋ねる。エージェントがレポート本体を読み、すべての結果を基準範囲と照合する" width="880">
 </p>
 
@@ -295,7 +295,7 @@ Dataページに落とせば ① Collect と ② Standardize が数秒で走り�
 ESL-Bench向けに生成したものを同梱しているので、投入にネットワークもキーも要らない。
 実データを載せるデプロイでは `SEED_DEMO_DATA=false` に。抽出の段がその12件の読み取りに
 対して**まだできていないこと**は、ここで曖昧にせず
-[docs/roadmap.md](docs/roadmap.md) に書いてある。
+[docs/roadmap.md](../docs/roadmap.md) に書いてある。
 
 ---
 
@@ -309,9 +309,9 @@ ESL-Bench向けに生成したものを同梱しているので、投入にネ�
 | --- | --- | --- |
 | 新しいツール | `mirobody/agent/tools/` | [ツールの追加](https://docs.mirobody.ai/en/tools/adding-tools/) |
 | Agent Skill(SKILL.md) | `mirobody/agent/skills/` | [Skills](https://docs.mirobody.ai/en/tools/skills/) |
-| 自前のエージェントハーネス | `AGENT_DIRS` → 自分のディレクトリ（同梱エージェントを置き換え） | [`mirobody/agent/README.md`](mirobody/agent/README.md) |
+| 自前のエージェントハーネス | `AGENT_DIRS` → 自分のディレクトリ（同梱エージェントを置き換え） | [`mirobody/agent/README.md`](../mirobody/agent/README.md) |
 | デバイスprovider | `mirobody/pulse/providers/` | [Provider統合](https://docs.mirobody.ai/en/development/provider-integration/) |
-| Claude Desktop、Cursor、自作のエージェントループからこれらのツールを使う | Settings → MCP（自分用の `/mcp` URL） | [MCPサーバー](https://docs.mirobody.ai/en/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](examples/07_claude_agent_sdk.py) |
+| Claude Desktop、Cursor、自作のエージェントループからこれらのツールを使う | Settings → MCP（自分用の `/mcp` URL） | [MCPサーバー](https://docs.mirobody.ai/en/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](../examples/07_claude_agent_sdk.py) |
 
 エージェントが持つツールはすべて `/mcp` 経由でも提供され、ユーザー単位でゲートされる。
 → [組み込みツール](https://docs.mirobody.ai/en/tools/built-in/) ·
@@ -325,8 +325,8 @@ ESL-Bench向けに生成したものを同梱しているので、投入にネ�
 | --- | --- | --- |
 | `pip install mirobody` | オフラインの指標解決と単位 ―― 2パッケージ、キー不要、ネットワーク不要 | [エンジン](https://docs.mirobody.ai/en/engine/) |
 | `pip install 'mirobody[parse]'` | 上に加えて、文書を測定値に ―― PDF、画像、Excel、Word、PowerPoint、テキスト。電子生成の報告書はテキストモデルのキー1つで足り、スキャンされたページだけがビジョンモデルに届く | [エンジン](https://docs.mirobody.ai/en/engine/) |
-| `pip install 'mirobody[agent]'` | deepagents ハーネスをライブラリとして ―― ミドルウェア、仮想ファイルシステムのバックエンド、チェックポインタ、モデルクライアント ―― 自分で動かすエージェントに | [自分のエージェントを持ち込む](CONTRIBUTING.md#-bringing-your-own-agent) |
-| `mirobody.bundle` | ビルド時：LOINCの軸テーブルとエイリアス元、シードやコーパスの生成に | [`mirobody/bundle.py`](mirobody/bundle.py) |
+| `pip install 'mirobody[agent]'` | deepagents ハーネスをライブラリとして ―― ミドルウェア、仮想ファイルシステムのバックエンド、チェックポインタ、モデルクライアント ―― 自分で動かすエージェントに | [自分のエージェントを持ち込む](../CONTRIBUTING.md#-bringing-your-own-agent) |
+| `mirobody.bundle` | ビルド時：LOINCの軸テーブルとエイリアス元、シードやコーパスの生成に | [`mirobody/bundle.py`](../mirobody/bundle.py) |
 | HTTP API | 自分のアプリからデプロイへ | [API概要](https://docs.mirobody.ai/en/api-reference/overview/) · [データ](https://docs.mirobody.ai/en/api-reference/data/) |
 | MCP | Claude、Cursor、任意のMCPクライアントが記録を読む | [MCPサーバー](https://docs.mirobody.ai/en/api-reference/mcp-servers/) |
 | Backboneモード | 自分のエージェント、こちらのデータ層 | [Backbone](https://docs.mirobody.ai/en/api-reference/backbone-mode/) |
@@ -374,7 +374,7 @@ frontend/        同梱のwebクライアント     アウトにだけあり、p
 パイプライン ―― インストールしても誰も動かせない19,000行 ―― を成果物から締め出す。
 
 → [アーキテクチャ](https://docs.mirobody.ai/en/concepts/architecture/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
+[CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---
 
@@ -392,19 +392,19 @@ frontend/        同梱のwebクライアント     アウトにだけあり、p
 
 ### リポジトリ内、コントリビューター向け
 
-各パッケージはそれが何であるかを述べる `README.md` を持ち、長文のガイドは [`docs/`](docs/) にある。
+各パッケージはそれが何であるかを述べる `README.md` を持ち、長文のガイドは [`docs/`](../docs/) にある。
 どの言語のREADMEから来ても、これらはすべて英語だ。
 
 | | Where |
 | --- | --- |
-| 実行できる例 | [`examples/`](examples/README.md) |
-| カーネル | [`kernel/`](mirobody/kernel/__init__.py) ―― 段階 → モジュール対応表 · [pipeline](docs/pipeline.md) ―― 11の段階と10の不変条件 |
-| ① 収集 | [`pulse/`](mirobody/pulse/README.md) · [providers](mirobody/pulse/providers/README.md) · [aggregation](mirobody/pulse/aggregate/README.md) · [Apple Health](mirobody/pulse/apple/README.md) |
-| ① ガイド | [connect a wearable](docs/provider-setup.md) · [write a provider](docs/provider-guide.md) · [file processing](docs/file-processing.md) · [`documents/`](mirobody/documents/__init__.py) · [Apple Health API](docs/apple-health.md) |
-| ② 標準化 | [`indicator/`](mirobody/indicator/README.md) · [indicators & units](mirobody/pulse/standardize/README.md) |
-| ③ 回答 | [`agent/`](mirobody/agent/README.md) · [tools](mirobody/agent/tools/README.md) · [the one data tool](docs/answers.md) · [medications](docs/medications.md) |
-| 下ばたらき | [configuration](mirobody/utils/config/README.md) · [database schema](mirobody/schema/README.md) · [the web client](docs/frontend.md) · [backup & restore](docs/backup-restore.md) |
-| 開発に参加 | [CONTRIBUTING.md](CONTRIBUTING.md) · [AGENTS.md](AGENTS.md) · [testing](docs/testing.md) · [aggregator script](docs/aggregation-tests.md) · [roadmap](docs/roadmap.md) · [CHANGELOG](CHANGELOG.md) · [SECURITY](SECURITY.md) |
+| 実行できる例 | [`examples/`](../examples/README.md) |
+| カーネル | [`kernel/`](../mirobody/kernel/__init__.py) ―― 段階 → モジュール対応表 · [pipeline](../docs/pipeline.md) ―― 11の段階と10の不変条件 |
+| ① 収集 | [`pulse/`](../mirobody/pulse/README.md) · [providers](../mirobody/pulse/providers/README.md) · [aggregation](../mirobody/pulse/aggregate/README.md) · [Apple Health](../mirobody/pulse/apple/README.md) |
+| ① ガイド | [connect a wearable](../docs/provider-setup.md) · [write a provider](../docs/provider-guide.md) · [file processing](../docs/file-processing.md) · [`documents/`](../mirobody/documents/__init__.py) · [Apple Health API](../docs/apple-health.md) |
+| ② 標準化 | [`indicator/`](../mirobody/indicator/README.md) · [indicators & units](../mirobody/pulse/standardize/README.md) |
+| ③ 回答 | [`agent/`](../mirobody/agent/README.md) · [tools](../mirobody/agent/tools/README.md) · [the one data tool](../docs/answers.md) · [medications](../docs/medications.md) |
+| 下ばたらき | [configuration](../mirobody/utils/config/README.md) · [database schema](../mirobody/schema/README.md) · [the web client](../docs/frontend.md) · [backup & restore](../docs/backup-restore.md) |
+| 開発に参加 | [CONTRIBUTING.md](../CONTRIBUTING.md) · [AGENTS.md](../AGENTS.md) · [testing](../docs/testing.md) · [aggregator script](../docs/aggregation-tests.md) · [roadmap](../docs/roadmap.md) · [CHANGELOG](../CHANGELOG.md) · [SECURITY](../SECURITY.md) |
 
 ---
 
@@ -412,8 +412,8 @@ frontend/        同梱のwebクライアント     アウトにだけあり、p
 
 最もレバレッジが高い貢献は、リゾルバが間違える用語ひとつだ。
 `mirobody resolve "<用語>"` を走らせ、答えが間違いか空なら
-[`resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv) に1行、
-[`test_engine_coverage.py`](mirobody/test_engine_coverage.py) にケースを1つ追加する
+[`resolver_overrides.tsv`](../mirobody/res/resolver_overrides.tsv) に1行、
+[`test_engine_coverage.py`](../mirobody/test_engine_coverage.py) にケースを1つ追加する
 ―― カバレッジのスコアがレビューだ。
 
 ```bash
@@ -421,7 +421,7 @@ pip install -e '.[test]' && pytest -q && lint-imports
 ```
 
 → [コントリビュートガイド](https://docs.mirobody.ai/en/development/contributing/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
+[CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---
 

--- a/archived/README.md
+++ b/archived/README.md
@@ -1,0 +1,15 @@
+# Archived README editions
+
+`README.zh-TW.md` and `README.ja.md` are frozen at **1.4.0** (2026-09-08) and are
+no longer updated. The live editions are [`README.md`](../README.md) (English)
+and [`README.zh-CN.md`](../README.zh-CN.md) (中文).
+
+Only these two Markdown files stopped moving. The engine's Traditional Chinese
+and Japanese support — the aliases, the zh-Hant fold table, the coverage tests —
+and the web client's four interface languages are unchanged. These files still
+call the three stages Collect · Standardize · Answers, the 1.4.0 names; the live
+editions say Collect · Translate (standardize) · Answer (agent).
+
+繁體中文：此譯本凍結於 1.4.0，不再更新；引擎對繁體中文的支援不受影響。
+
+日本語：この翻訳は 1.4.0 で凍結され、更新されません。エンジンの日本語対応は変わりません。

--- a/archived/README.zh-TW.md
+++ b/archived/README.zh-TW.md
@@ -6,8 +6,8 @@
 
 已上線的消費者健康產品 **Theta Wellness** 由 Mirobody 驅動——註冊使用者 5,000+，每日活躍 500+。
 
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](pyproject.toml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg?logo=python&logoColor=white)](../pyproject.toml)
 [![PyPI Downloads](https://img.shields.io/pepy/dt/mirobody?label=PyPI%20Downloads&color=orange)](https://pepy.tech/projects/mirobody)
 [![Benchmarks](https://img.shields.io/badge/%F0%9F%A4%97_Benchmarks-4k%2B_downloads_each-FFD21E.svg)](https://huggingface.co/healthmemoryarena)
 [![arXiv](https://img.shields.io/badge/arXiv-2604.02834-b31b1b.svg)](https://arxiv.org/abs/2604.02834)
@@ -15,13 +15,13 @@
 
 **[📚 文件](https://docs.mirobody.ai/)** · **[💬 雲端聊天服務——chat.mirobody.ai](https://chat.mirobody.ai/)** · **[🔌 API 平台——platform.mirobody.ai](https://platform.mirobody.ai/)**
 
-**[English](README.md)** · **[简体中文](README.zh-CN.md)** · **繁體中文** · **[日本語](README.ja.md)**
+**[English](../README.md)** · **[简体中文](../README.zh-CN.md)** · **繁體中文** · **[日本語](README.ja.md)**
 
 *血液檢驗、穿戴裝置、基因體、影像——全部都是碎片化的，彼此互不相容。
 在 AI 能真正理解你的健康之前，必須先有人把這些訊號統一成一個 AI
 真正讀得懂的標準。這正是這個引擎在做的事。*
 
-<img src="docs/images/where-your-data-comes-from.zh-TW.svg" alt="從穿戴裝置到餐點照片——一種標準格式，AI 可直接讀取。" width="920">
+<img src="../docs/images/where-your-data-comes-from.zh-TW.svg" alt="從穿戴裝置到餐點照片——一種標準格式，AI 可直接讀取。" width="920">
 
 </div>
 
@@ -29,9 +29,9 @@
 
 | 階段 | 意思 | 位置 |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **① 收集** | 把訊號拉進來：3 家裝置提供者 + 一個 SQL 來源 · 7 種檔案格式 · Apple Health（只接收：由已簽名的 iOS 用戶端推送進來） | [`pulse/`](mirobody/pulse/) |
-| **② 標準化** | 一套標準：把任何一筆讀值解析成標準代碼（LOINC · SNOMED CT · RxNorm），統一單位，並落地到 FHIR 認可的碼制 | [`indicator/`](mirobody/indicator/) |
-| **③ 解答** | 推理：agent 透過虛擬檔案系統讀取*原始文件*，並用圖表與引用來源作答 | [`agent/`](mirobody/agent/) |
+| **① 收集** | 把訊號拉進來：3 家裝置提供者 + 一個 SQL 來源 · 7 種檔案格式 · Apple Health（只接收：由已簽名的 iOS 用戶端推送進來） | [`pulse/`](../mirobody/pulse/) |
+| **② 標準化** | 一套標準：把任何一筆讀值解析成標準代碼（LOINC · SNOMED CT · RxNorm），統一單位，並落地到 FHIR 認可的碼制 | [`indicator/`](../mirobody/indicator/) |
+| **③ 解答** | 推理：agent 透過虛擬檔案系統讀取*原始文件*，並用圖表與引用來源作答 | [`agent/`](../mirobody/agent/) |
 
 ---
 
@@ -45,11 +45,11 @@ mirobody resolve "LDL cholesterol" 血红蛋白 ヘモグロビン "空腹血糖
 ```
 
 <p align="center">
-  <img src="docs/images/resolve-demo.zh-TW.gif"
+  <img src="../docs/images/resolve-demo.zh-TW.gif"
        alt="mirobody resolve：四種語言落到同一個 LOINC 碼，完全離線" width="880">
 </p>
 
-> 這是真實輸出，而且 GIF 是建置產物——[`docs/demo/resolve.html`](docs/demo/resolve.html) 由 [`scripts/make_demo_gifs.py`](scripts/make_demo_gifs.py) 渲染，所以它不會和它聲稱展示的指令走散。
+> 這是真實輸出，而且 GIF 是建置產物——[`docs/demo/resolve.html`](../docs/demo/resolve.html) 由 [`scripts/make_demo_gifs.py`](../scripts/make_demo_gifs.py) 渲染，所以它不會和它聲稱展示的指令走散。
 
 ```python
 from mirobody.engine import resolve, resolve_reading
@@ -88,7 +88,7 @@ resolve("血脂").resolved                                 # False    這是類�
 - **單位**歸一到約 310 個 UCUM 家族，含因次分析、依 LOINC 碼索引的摩爾質量橋接，
   以及對 `%` 與 `10*9/L` 的明確拒絕。305 個標準 pulse 指標。
 - **還有第二層，而且刻意保持可選。** 上面全是詞法的，遇到不認識的詞就棄答——這是個誠實
-  的天花板。餘弦召回（[`indicator/semantic.py`](mirobody/indicator/semantic.py)）能越過
+  的天花板。餘弦召回（[`indicator/semantic.py`](../mirobody/indicator/semantic.py)）能越過
   它，但**它無法棄答**：面對從沒見過的詞，它會用和正確答案相同的信賴度返回最近鄰，沒有
   任何閾值能把兩者分開。**repo 裡沒有向量矩陣，也沒有現成的可供下載**：它是 108,248 條
   LOINC 列 × 1024 維（約 221 MB），且和 (provider, model) 綁死，要用
@@ -99,7 +99,7 @@ resolve("血脂").resolved                                 # False    這是類�
   → [語義召回](https://docs.mirobody.ai/zh/concepts/semantic-recall/)：基準數字、兩道軸向
   閘門，以及為什麼 `min_score` 不是正確性閾值。
 - **這個說法我們是量出來的，不是斷言的。**
-  [`test_engine_coverage.py`](mirobody/test_engine_coverage.py) 用健檢實際會開的
+  [`test_engine_coverage.py`](../mirobody/test_engine_coverage.py) 用健檢實際會開的
   套組給離線解析器打分，按報告實際列印的寫法，涵蓋英文、简体中文、繁體中文、日本語，
   外加平台 API 教的穿戴式詞彙。**今天 211/211；寫出來那天是 32/94。** 它評的是
   **臨床**正確性：把 `血红蛋白` 答成 HbA1c 的碼算失敗，而 `血脂` 必須解析為空。
@@ -140,7 +140,7 @@ LOINC 只為 9 個給出替代碼,拒答基本等於把「一個有點舊但正�
 
 **涵蓋不等於召回,而且這道落差是我們的、不是 LOINC 的**:`Body bone mass` 在這裡能解析到
 `101685-6`,中文的 `骨量` 卻落到一個牙科體積碼上,因為沒有別名把它路由過去。
-這正是 [`res/resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv) 存在的理由
+這正是 [`res/resolver_overrides.tsv`](../mirobody/res/resolver_overrides.tsv) 存在的理由
 ——一行由人寫下的意圖,永遠贏過索引裡的表面匹配。
 
 → [loinc.org](https://loinc.org/) · [授權](https://loinc.org/license/) ·
@@ -225,12 +225,12 @@ DeepSeek/Kimi），視覺解析使用 qwen3-vl，語義搜尋使用 text-embeddi
 資料隔離由此直接可見。
 
 <p align="center">
-  <img src="docs/images/care-circle-demo.zh-TW.gif"
+  <img src="../docs/images/care-circle-demo.zh-TW.gif"
        alt="自己帳號的指標與上傳檔案，切換到 Demo 的共享紀錄，打開兩年的 HbA1c" width="880">
 </p>
 
 <div align="center">
-<img src="docs/images/your-care-circle.zh-TW.svg" alt="你自己薄薄的一份，旁邊是她厚厚的一份——後者你只能檢視。" width="820">
+<img src="../docs/images/your-care-circle.zh-TW.svg" alt="你自己薄薄的一份，旁邊是她厚厚的一份——後者你只能檢視。" width="820">
 </div>
 
 她的 HbA1c 是最該先打開的一條序列——因為它改善過，然後沒保住：
@@ -248,7 +248,7 @@ DeepSeek/Kimi），視覺解析使用 qwen3-vl，語義搜尋使用 text-embeddi
 2026-04 之後就沒有了，建議補做一次。
 
 <p align="center">
-  <img src="docs/images/ask-circle-demo.zh-TW.gif"
+  <img src="../docs/images/ask-circle-demo.zh-TW.gif"
        alt="用繁體中文詢問共享紀錄的 HbA1c；agent 查詢、把化驗值與感測器序列畫在一起、讀出趨勢" width="880">
 </p>
 
@@ -257,7 +257,7 @@ DeepSeek/Kimi），視覺解析使用 qwen3-vl，語義搜尋使用 text-embeddi
 在幾秒內跑完：十二個分析物帶著數值和單位出來，每一個都能點回它被讀出來的那一頁。
 
 <p align="center">
-  <img src="docs/images/upload-demo.zh-TW.gif"
+  <img src="../docs/images/upload-demo.zh-TW.gif"
        alt="把檢驗報告 PDF 拖到 Data 頁；十二個分析物被抽取出來，每一個都連回它的原始檔案" width="880">
 </p>
 
@@ -266,7 +266,7 @@ DeepSeek/Kimi），視覺解析使用 qwen3-vl，語義搜尋使用 text-embeddi
 你的檔案庫裡只有這一份，所以無法呈現趨勢。
 
 <p align="center">
-  <img src="docs/images/ask-own-demo.zh-TW.gif"
+  <img src="../docs/images/ask-own-demo.zh-TW.gif"
        alt="詢問你自己剛上傳的面板；agent 讀報告本身，把每個結果對照參考區間標出來" width="880">
 </p>
 
@@ -276,7 +276,7 @@ DeepSeek/Kimi），視覺解析使用 qwen3-vl，語義搜尋使用 text-embeddi
 所有數值都是合成的——由 [mirobody-eval](https://github.com/thetahealth/mirobody-eval)
 為 ESL-Bench 生成後固化在 repo 裡，所以灌資料不需要連網、不需要 key。要讓部署承載
 真實資料，把 `SEED_DEMO_DATA` 設為 false。抽取這一步對那十二條讀數**還做不到**什麼，
-寫在 [docs/roadmap.md](docs/roadmap.md) 裡，而不是在這裡含糊過去。
+寫在 [docs/roadmap.md](../docs/roadmap.md) 裡，而不是在這裡含糊過去。
 
 ---
 
@@ -290,9 +290,9 @@ MCP 工具，不需要額外接線。
 | --- | --- | --- |
 | 一個新工具 | `mirobody/agent/tools/` | [新增工具](https://docs.mirobody.ai/zh/tools/adding-tools/) |
 | 一個 Agent Skill（SKILL.md） | `mirobody/agent/skills/` | [Skills](https://docs.mirobody.ai/zh/tools/skills/) |
-| 自己的 agent harness | `AGENT_DIRS` → 你的目錄（取代內建 agent） | [`mirobody/agent/README.md`](mirobody/agent/README.md) |
+| 自己的 agent harness | `AGENT_DIRS` → 你的目錄（取代內建 agent） | [`mirobody/agent/README.md`](../mirobody/agent/README.md) |
 | 一個裝置 provider | `mirobody/pulse/providers/` | [Provider 接入](https://docs.mirobody.ai/zh/development/provider-integration/) |
-| 在 Claude Desktop、Cursor 或你自己的 agent 迴圈裡用這些工具 | Settings → MCP（你的個人 `/mcp` URL） | [MCP 服務](https://docs.mirobody.ai/zh/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](examples/07_claude_agent_sdk.py) |
+| 在 Claude Desktop、Cursor 或你自己的 agent 迴圈裡用這些工具 | Settings → MCP（你的個人 `/mcp` URL） | [MCP 服務](https://docs.mirobody.ai/zh/api-reference/mcp-servers/) · [`examples/07_claude_agent_sdk.py`](../examples/07_claude_agent_sdk.py) |
 
 agent 擁有的每個工具同時透過 `/mcp` 對外提供，依使用者門控。
 → [內建工具](https://docs.mirobody.ai/zh/tools/built-in/) ·
@@ -306,8 +306,8 @@ agent 擁有的每個工具同時透過 `/mcp` 對外提供，依使用者門控
 | --- | --- | --- |
 | `pip install mirobody` | 離線的指標解析與單位換算 —— 2 個套件，不需要 key，不需要網路 | [引擎](https://docs.mirobody.ai/zh/engine/) |
 | `pip install 'mirobody[parse]'` | 在上一列之上，把文件變成讀數 —— PDF、圖片、Excel、Word、PowerPoint、純文字；原生電子版報告只需要一個文字模型的 key，只有掃描頁才會送到視覺模型 | [引擎](https://docs.mirobody.ai/zh/engine/) |
-| `pip install 'mirobody[agent]'` | 把 deepagents harness 當函式庫用 —— 中介層、虛擬檔案系統後端、checkpointer、模型用戶端 —— 裝進你自己跑的 agent | [自帶 agent](CONTRIBUTING.md#-bringing-your-own-agent) |
-| `mirobody.bundle` | 建置期：LOINC 軸表與別名來源，用於產生種子或語料 | [`mirobody/bundle.py`](mirobody/bundle.py) |
+| `pip install 'mirobody[agent]'` | 把 deepagents harness 當函式庫用 —— 中介層、虛擬檔案系統後端、checkpointer、模型用戶端 —— 裝進你自己跑的 agent | [自帶 agent](../CONTRIBUTING.md#-bringing-your-own-agent) |
+| `mirobody.bundle` | 建置期：LOINC 軸表與別名來源，用於產生種子或語料 | [`mirobody/bundle.py`](../mirobody/bundle.py) |
 | HTTP API | 你的應用對接一個部署 | [API 總覽](https://docs.mirobody.ai/zh/api-reference/overview/) · [資料](https://docs.mirobody.ai/zh/api-reference/data/) |
 | MCP | Claude、Cursor 或任何 MCP 用戶端讀取使用者紀錄 | [MCP 服務](https://docs.mirobody.ai/zh/api-reference/mcp-servers/) |
 | Backbone 模式 | 你自己的 agent，我們的資料層 | [Backbone](https://docs.mirobody.ai/zh/api-reference/backbone-mode/) |
@@ -353,7 +353,7 @@ numpy 外不匯入任何東西，引擎永不匯入 agent 層——違反即 `li
 把語料建置流程與 v2 語義管線——19,000 行裝了也跑不了的程式碼——擋在產物之外。
 
 → [架構](https://docs.mirobody.ai/zh/concepts/architecture/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
+[CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---
 
@@ -371,27 +371,27 @@ numpy 外不匯入任何東西，引擎永不匯入 agent 層——違反即 `li
 
 ### repo 內，面向貢獻者
 
-每個套件都帶一份 `README.md` 說明它是什麼；長文指南在 [`docs/`](docs/)。
+每個套件都帶一份 `README.md` 說明它是什麼；長文指南在 [`docs/`](../docs/)。
 無論你從哪個語言的 README 過來，這些都是英文的。
 
 | | Where |
 | --- | --- |
-| 可執行範例 | [`examples/`](examples/README.md) |
-| 內核 | [`kernel/`](mirobody/kernel/__init__.py) —— 階段 → 模組對照 · [pipeline](docs/pipeline.md) —— 十一個階段、十條不變量 |
-| ① 收集 | [`pulse/`](mirobody/pulse/README.md) · [providers](mirobody/pulse/providers/README.md) · [aggregation](mirobody/pulse/aggregate/README.md) · [Apple Health](mirobody/pulse/apple/README.md) |
-| ① 指南 | [connect a wearable](docs/provider-setup.md) · [write a provider](docs/provider-guide.md) · [file processing](docs/file-processing.md) · [`documents/`](mirobody/documents/__init__.py) · [Apple Health API](docs/apple-health.md) |
-| ② 標準化 | [`indicator/`](mirobody/indicator/README.md) · [indicators & units](mirobody/pulse/standardize/README.md) |
-| ③ 回答 | [`agent/`](mirobody/agent/README.md) · [tools](mirobody/agent/tools/README.md) · [the one data tool](docs/answers.md) · [medications](docs/medications.md) |
-| 底層設施 | [configuration](mirobody/utils/config/README.md) · [database schema](mirobody/schema/README.md) · [the web client](docs/frontend.md) · [backup & restore](docs/backup-restore.md) |
-| 參與開發 | [CONTRIBUTING.md](CONTRIBUTING.md) · [AGENTS.md](AGENTS.md) · [testing](docs/testing.md) · [aggregator script](docs/aggregation-tests.md) · [roadmap](docs/roadmap.md) · [CHANGELOG](CHANGELOG.md) · [SECURITY](SECURITY.md) |
+| 可執行範例 | [`examples/`](../examples/README.md) |
+| 內核 | [`kernel/`](../mirobody/kernel/__init__.py) —— 階段 → 模組對照 · [pipeline](../docs/pipeline.md) —— 十一個階段、十條不變量 |
+| ① 收集 | [`pulse/`](../mirobody/pulse/README.md) · [providers](../mirobody/pulse/providers/README.md) · [aggregation](../mirobody/pulse/aggregate/README.md) · [Apple Health](../mirobody/pulse/apple/README.md) |
+| ① 指南 | [connect a wearable](../docs/provider-setup.md) · [write a provider](../docs/provider-guide.md) · [file processing](../docs/file-processing.md) · [`documents/`](../mirobody/documents/__init__.py) · [Apple Health API](../docs/apple-health.md) |
+| ② 標準化 | [`indicator/`](../mirobody/indicator/README.md) · [indicators & units](../mirobody/pulse/standardize/README.md) |
+| ③ 回答 | [`agent/`](../mirobody/agent/README.md) · [tools](../mirobody/agent/tools/README.md) · [the one data tool](../docs/answers.md) · [medications](../docs/medications.md) |
+| 底層設施 | [configuration](../mirobody/utils/config/README.md) · [database schema](../mirobody/schema/README.md) · [the web client](../docs/frontend.md) · [backup & restore](../docs/backup-restore.md) |
+| 參與開發 | [CONTRIBUTING.md](../CONTRIBUTING.md) · [AGENTS.md](../AGENTS.md) · [testing](../docs/testing.md) · [aggregator script](../docs/aggregation-tests.md) · [roadmap](../docs/roadmap.md) · [CHANGELOG](../CHANGELOG.md) · [SECURITY](../SECURITY.md) |
 
 ---
 
 ## 🤝 貢獻
 
 槓桿最高的貢獻是一個解析器答錯的詞。跑 `mirobody resolve "<詞>"`，如果答案錯了
-或是空的，就往 [`resolver_overrides.tsv`](mirobody/res/resolver_overrides.tsv)
-加一行，再往 [`test_engine_coverage.py`](mirobody/test_engine_coverage.py) 加一個
+或是空的，就往 [`resolver_overrides.tsv`](../mirobody/res/resolver_overrides.tsv)
+加一行，再往 [`test_engine_coverage.py`](../mirobody/test_engine_coverage.py) 加一個
 用例——覆蓋率分數就是評審。
 
 ```bash
@@ -399,7 +399,7 @@ pip install -e '.[test]' && pytest -q && lint-imports
 ```
 
 → [貢獻指南](https://docs.mirobody.ai/zh/development/contributing/) ·
-[CONTRIBUTING.md](CONTRIBUTING.md)
+[CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,15 +24,18 @@ notes to PyPI under a filename that told open-source readers to ignore it.
 | ① | [provider-guide.md](provider-guide.md) | writing a data provider end to end — the long one |
 | ① | [file-processing.md](file-processing.md) | a file becomes text by kind (`mirobody/documents/`: PDF text layer, OCR for scanned pages only, Office, text), then LLM extraction |
 | ① | [apple-health.md](apple-health.md) | Apple Health export + CDA import |
+| ② | [standardization.md](standardization.md) | the long form of ② Translate (standardize): the concept graph, the alias tiers, LOINC 2.82 vs 2.83, the opt-in semantic tier — moved out of the README in 1.4.1 |
 | ② | [vocabulary-build.md](vocabulary-build.md) | rebuilding `mirobody/res/` from the raw LOINC / SNOMED CT / RxNorm releases — needs a UMLS licence |
 | ③ | [answers.md](answers.md) | the one health-data tool: its matrix, its envelope, its governance, and the PHI discipline |
 | ③ | [medications.md](medications.md) | the medication model, its state tables and its instruction grammar (provisional) |
 | ③ | [frontend.md](frontend.md) | how the bundled web client is served, and how to replace it |
+| ③ | [walkthrough.md](walkthrough.md) | the four-minute care-circle walkthrough, all four scenes |
+| | [repository-layout.md](repository-layout.md) | the directory map and the two forms the code ships in (library vs application) |
 | | [backup-restore.md](backup-restore.md) | what to copy, how to get it back, and what changes on upgrade |
 | | [testing.md](testing.md) | test layout, markers, snapshots, release gates |
 | | [aggregation-tests.md](aggregation-tests.md) | the daily-rollup test suite in detail |
 
-Start at the README's **Repository layout** section ([README.md](../README.md)) if you want the map rather than a
+Start at [repository-layout.md](repository-layout.md) if you want the map rather than a
 specific subsystem, and [roadmap.md](roadmap.md) for known gaps and deferred
 work — each entry states the measurement that motivated it.
 
@@ -41,8 +44,8 @@ work — each entry states the measurement that motivated it.
 Short, and about *that package only*:
 
 - [`mirobody/pulse/`](../mirobody/pulse/README.md) — ① Collect
-- [`mirobody/indicator/`](../mirobody/indicator/README.md) — ② Standardize
-- [`mirobody/agent/`](../mirobody/agent/README.md) — ③ Answers
+- [`mirobody/indicator/`](../mirobody/indicator/README.md) — ② Translate (standardize)
+- [`mirobody/agent/`](../mirobody/agent/README.md) — ③ Answer (agent)
 - [`mirobody/agent/tools/`](../mirobody/agent/tools/README.md) — the MCP tool surface
 - [`mirobody/pulse/apple/`](../mirobody/pulse/apple/README.md) — Apple Health import
 - [`mirobody/pulse/aggregate/`](../mirobody/pulse/aggregate/README.md) — daily rollups

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -1,0 +1,52 @@
+# Repository layout
+
+Where each of the three stages — ① Collect, ② Translate (standardize), ③ Answer (agent) — lives,
+and the two forms the code ships in. Moved here from the README in 1.4.1; the
+README keeps the one-line map.
+
+
+```
+mirobody/
+├── engine.py    the front door — resolve() and parse_file()
+├── units/       UCUM units, unit_family, conversions          ┐ the library:
+├── lexical.py   surface folding + the CJK-aware tokenizer     │ numpy only,
+├── bundle.py    build-time: the axis table and alias sources    │
+├── res/         the shipped LOINC bundles, res/metrics.tsv       │
+├── kernel/      what health data MEANS, as pure functions:       │
+│                metrics · series · quality · overlay · meds ·    │
+│                query · tools · ops · connect · sink · events ·  │
+│                evidence · memory · vendors/                     ┘ 2 packages
+├── documents/   a file becomes text, by kind — PDF text layer, OCR for scanned pages only, Office, text   [parse]
+├── pulse/       ① Collect     — providers, file parsing, store, aggregate, read (Postgres)
+├── indicator/   ② Translate (standardize) — resolver internals, concept graph, bundle build
+├── agent/       ③ Answer (agent)     — the agent: models/ fs/ wire/ middleware/ tools/ chat/
+├── mcp/         the MCP server
+├── server/      the HTTP application — routers, auth, the bundled web client
+├── utils/       mechanisms a consumer binds: config, db, sse, net, llm_output, prompts, log
+├── user/        identity and the care circle — who may read whose record
+└── schema/      the DDL, replayed at boot in dev
+
+demo/            the care-circle demo fixture, beside frontend/ — a checkout
+frontend/        the bundled web client                          has them, a
+                                                                 pip install
+                                                                 does not
+```
+
+**Two forms, and they want opposite things.** The PyPI package is a LIBRARY and
+is meant to be small enough that nobody has to think about it: `pip install
+mirobody` is **2 packages, 52 MB** — the entries above the `documents/` line, on numpy.
+`[parse]` adds document reading, `[agent]` the harness as a library; `[app]` is everything, and the only thing that
+installs it is `requirements.txt`, because the Docker application is
+`git clone && ./deploy.sh` and never a pip install.
+
+**Machine-enforced, not documented:** four import-linter contracts hold the
+lines — the library layer imports nothing but numpy, and the engine never
+imports the agent layer — and `lint-imports` fails the build. A separate gate, `scripts/check_wheel_data.py`, keeps the bundle-build passes and the
+v2 semantic pipeline — 19,000 lines nobody who installs the package can run —
+out of the artifact.
+
+→ [Architecture](https://docs.mirobody.ai/en/concepts/architecture/) ·
+[CONTRIBUTING.md](../CONTRIBUTING.md)
+
+---
+

--- a/docs/standardization.md
+++ b/docs/standardization.md
@@ -1,0 +1,122 @@
+# Standardization in depth
+
+The long form of the README's **② Translate (standardize)** stage: what the shipped
+vocabulary is, what it deliberately does not do, which LOINC release it is cut
+from and why, and the opt-in semantic tier. Every exact figure here is the same
+one the README quotes; `mirobody/test_readme_numbers.py` checks the README, and
+this page follows it.
+
+<p align="center"><img src="images/where-your-data-comes-from.svg" alt="From wearables to food photos — one standard format, ready for AI." width="920"></p>
+
+## What the layer provides
+
+Standardization here is not a lookup table but a complete terminology-normalization system:
+
+- **Concept graph**: 440,961 nodes · 22,044,110 cross-vocabulary edges ·
+  **595,746 source ids** distilled into canonical concepts (LOINC · SNOMED CT ·
+  RxNorm bridges).
+- **49,253 multilingual aliases** (中文 22,578 · 日本語 16,809 · +5:
+  de·es·fr·ko·ru). `hemoglobin`, `血红蛋白`, `血紅素` and `ヘモグロビン` all land
+  on LOINC 718-7.
+- **繁體中文 is two problems, handled as two.** Script folding is mechanical
+  (a shipped 3,336-character zh-Hant → zh-Hans table); vocabulary is not — Taiwan
+  usage picks different words, and folding `血紅素` yields the HbA1c code. Those
+  terms are curated under their Traditional spelling, and a curated row always
+  beats a fold.
+- **Units** normalized to ~310 UCUM families, with dimensional analysis, a
+  molar-mass bridge keyed by LOINC code, and an explicit refusal for `%` vs
+  `10*9/L`. 305 standard pulse indicators.
+- **A second tier exists, and stays opt-in.** Everything above is lexical, so it
+  abstains on terms it does not know — an honest ceiling. Cosine recall
+  ([`indicator/semantic.py`](../mirobody/indicator/semantic.py)) reaches past it but
+  **cannot abstain**: for a term it has never seen it returns its nearest
+  neighbour with the confidence of a correct answer, and no threshold separates
+  the two. **No matrix ships and none is published to download**: it is 108,248
+  LOINC rows × 1024 dims (~221 MB) and it is specific to one (provider, model)
+  pair, so `scripts/build_loinc_embeddings.py` builds yours against the
+  embedding model you configure. A matrix from a different model does not
+  error — it ranks confidently in the wrong space, which is why the build
+  stamps `<matrix>.meta.json` and loading refuses a mismatch. Until you point
+  `MIROBODY_SEMANTIC_INDEX` at one, `resolve()` is unchanged; after, use it to
+  *suggest* a code a human confirms, never to mint an identity.
+  → [Semantic recall](https://docs.mirobody.ai/en/concepts/semantic-recall/) — the
+  benchmark, the two axis gates, and why `min_score` is not a correctness threshold.
+- **We measure the claim instead of asserting it.**
+  [`test_engine_coverage.py`](../mirobody/test_engine_coverage.py) scores the offline
+  resolver against the panels an ordinary checkup includes, written the way a report
+  prints them, in English, 简体中文, 繁體中文 and 日本語 — plus the wearable
+  vocabulary the platform API teaches. **211/211 today; it scored 32/94 the day it
+  was written.** It grades *clinical* correctness: answering `血红蛋白` with the
+  HbA1c code is a failure, and `血脂` is required to resolve to nothing.
+
+```bash
+pytest mirobody/test_engine_coverage.py -s   # offline, about a second
+```
+
+### Two semantic indexes, and which one you get for free
+
+The matrix above is the **downloadable-corpus** tier — LOINC rows embedded once,
+built by you against your own embedding model. The deployment has a second,
+unrelated index that comes for free: indicator search in the app embeds **your
+own indicator names**, not the LOINC corpus. The worker's `IndicatorSyncTask`
+writes `th_series_dim.embedding_qwen3_8b` on each ingest, and a query is matched
+against that. It needs `mirobody worker` running, which `./deploy.sh` starts, and
+an embedding provider — the same OpenAI-compatible key that runs chat, or a
+self-hosted model behind any `/v1/embeddings` endpoint reached through
+`<PROVIDER>_BASE_URL`. Neither index changes what `resolve()` answers.
+
+### Which LOINC, and what it does and does not cover
+
+The shipped bundle is cut from **LOINC 2.82**, and the package says so at
+runtime rather than in a comment that can drift:
+
+```python
+>>> import mirobody; mirobody.BUNDLE_VERSION
+'loinc-2.82+2026.08.28-af2524b7a285'
+```
+
+The release, the cut date, and a digest over the bundle's own members — so a
+build-time consumer of the vocabulary and a runtime `pip` pin can be asserted
+to be the same corpus, which the package version alone never told you.
+[LOINC's licence](https://loinc.org/license/) requires every copy to carry the
+version number; `res/fhir_loinc_bundle.NOTICE` does, and
+`scripts/stamp_bundle_version.py --check` keeps the stamp honest.
+
+**Why 2.82 and not 2.83.** The axis table and the 677k-row corpus are coupled
+through the folded `LONG_COMMON_NAME`, and 2.83 renamed 2,842 of them
+(`Cerebral spinal fluid` → `Cerebrospinal Fluid` and that family). Measured:
+upgrading the axis alone loses **3,486** name→code links and gains none, so a
+real upgrade means rebuilding the corpus — which spans SNOMED CT, RxNorm, CVX
+and DCM, each licensed separately and none redistributable here. The known
+cost of staying: 650 codes that 2.83 has marked DISCOURAGED or DEPRECATED are
+still answerable, which shows up as 52 of the 6,815 benchmark cases that
+resolve. Withholding them was measured too and not taken — LOINC offers a
+replacement for only 9 of the 658, so it would mostly turn a dated code into no
+code, and a reading with no code cannot be grouped at all.
+
+**LOINC covers more of the wearable world than people expect.** It is not only
+lab panels: `BDYWGT.*` codes body composition (`101685-6` body bone mass,
+`73964-9` body muscle mass, `101684-9` percentage of body water), `HRTRATE.*`
+distinguishes resting heart rate (`40443-4`) from a spot reading, and there are
+codes for step counts (`41950-7`), sleep stages (`93831-6` deep, `93830-8`
+light), HRV SDNN (`112429-6`), VO₂ peak and elevation climbed. Where it stops
+is vendor composites — Garmin's Body Battery and stress score have no code,
+correctly, because they are one company's formula rather than a measurement.
+
+**Coverage of a vocabulary is not the same as recall on it**, and the gap is
+ours, not LOINC's: `Body bone mass` resolves to `101685-6` here, while the
+Chinese `骨量` resolves to a dental volume code, because no alias routes it.
+That is what [`res/resolver_overrides.tsv`](../mirobody/res/resolver_overrides.tsv)
+is for — a row written by a person beats a surface match in the index, every
+time.
+
+→ [loinc.org](https://loinc.org/) · [licence](https://loinc.org/license/) ·
+[release notes](https://loinc.org/kb/) · the download is free but requires an
+account, which is why the derived bundle ships and the source release does not.
+
+→ [Standardization](https://docs.mirobody.ai/en/api-reference/standardization/) ·
+[Architecture](https://docs.mirobody.ai/en/concepts/architecture/) ·
+[Data flow](https://docs.mirobody.ai/en/concepts/data-flow/)
+
+---
+

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,0 +1,85 @@
+# The whole engine, in four minutes
+
+The care-circle walkthrough the README used to carry in full. Each part is
+recorded against a running `./deploy.sh` stack with `SEED_DEMO_DATA` on; the
+README shows three of the four scenes and links here for the fourth.
+
+
+`SEED_DEMO_DATA` defaults to on, so the ① → ② → ③ chain is walkable the moment
+`./deploy.sh` finishes — signing in and browsing the seeded record need no
+key; the upload extraction in part 2 and the questions after it ride the one
+key configured above. Four parts, each recorded against the running stack.
+
+**1 · Arrive.** You sign in owning a **thin** record — a few weeks of
+self-tracked vitals and one unremarkable checkup, seeded as your own — and find
+one synthetic person sharing a **thick** one with you: **Demo (synthetic)**,
+244 indicators and 14,273 readings across two years, five documents the agent
+can `read_file`. Same question, two records: *your* HbA1c answers with one
+boring-normal value from data you own; *hers* answers with a two-year story
+from data you can only view. Isolation you can see, not just read about.
+
+<p align="center">
+  <img src="images/care-circle-demo.gif"
+       alt="Your own account's indicators and an uploaded report, then switching to Demo's shared record and opening two years of HbA1c" width="880">
+</p>
+
+<div align="center">
+<img src="images/your-care-circle.svg" alt="Your own thin record next to hers — the thick one you can only view." width="820">
+</div>
+
+The switch in that diagram is a column, not a promise:
+`care_circle_members.health_access`, `NOT NULL DEFAULT 0`, on **your own** row.
+Being invited into a circle shares nothing — the member decides, and no other
+person's action can raise it. The check that reads it raises rather than
+returning a falsy value, so a route that forgets to look answers 403 instead of
+handing over a record.
+[`examples/06_care_circle_rules.py`](../examples/06_care_circle_rules.py) prints
+the whole decision table offline.
+
+**2 · ③ Answer (agent), on someone else's record.** Ask about her HbA1c and the agent
+finds the data itself, cross-references the lab draws against the sensor-derived
+series, and charts both — then tells you the improvement did not hold.
+
+<p align="center">
+  <img src="images/ask-circle-demo.gif"
+       alt="Asking about the shared record's HbA1c; the agent queries, charts lab and sensor series together, and reads the trend" width="880">
+</p>
+
+```
+lab-drawn HbA1c   7.2 % (2024-04)  →  6.5 % (2024-10)  →  6.6 % (2025-04)
+                  only 3 lab draws in two years — the sensor eA1C has 104
+```
+
+**3 · ① Collect + ② Translate (standardize), on your own.**
+`demo/lab_report_2025-10-15.pdf` is a panel deliberately held out of the
+seed, so uploading it is not a no-op. Drop it on the Data page and twelve
+analytes come out with their values and units in seconds, each linking back to
+the page it was read from.
+
+<p align="center">
+  <img src="images/upload-demo.gif"
+       alt="Dropping a lab-report PDF on the Data page; twelve analytes extracted, each linked to its source file" width="880">
+</p>
+
+**4 · ③ Answer (agent), on what you just uploaded.** Ask again, now about your own
+record. The agent reads the report through the virtual filesystem, flags all
+twelve results against their printed reference ranges — and says plainly that one
+date is not a trend.
+
+<p align="center">
+  <img src="images/ask-own-demo.gif"
+       alt="Asking about your own just-uploaded panel; the agent reads the report and flags every result against its reference range" width="880">
+</p>
+
+That contrast is the demo's point: **two years of history buys a trend, one panel
+buys an interpretation.** Both answers cite what they read.
+
+Every value is synthetic — generated for ESL-Bench by
+[mirobody-eval](https://github.com/thetahealth/mirobody-eval) and vendored, so the
+seed needs no network and no key. Set `SEED_DEMO_DATA=false` for a deployment that
+will hold real data. What the extraction pass does *not* yet do with those twelve
+readings is written down in [docs/roadmap.md](roadmap.md) rather than glossed
+over here.
+
+---
+

--- a/mirobody/test_one_key_defaults.py
+++ b/mirobody/test_one_key_defaults.py
@@ -121,15 +121,26 @@ def test_both_gateway_paths_are_fully_wired_for_embeddings():
             )
 
 
-def test_every_readme_hands_out_both_key_links():
-    """The README's job is to hand a visitor a working path — OpenRouter
-    first, DashScope when openrouter.ai is unreachable — with the actual
-    place to get the key."""
-    for name in ("README.md", "README.zh-CN.md", "README.zh-TW.md", "README.ja.md"):
+def test_every_live_readme_hands_out_the_openai_compatible_path():
+    """The README's job is to hand a visitor a working path with the actual
+    place to get the key. Since 1.4.1 the path it recommends is any
+    OpenAI-compatible endpoint — OpenAI or OpenRouter, each with its key page,
+    or another gateway through `<PROVIDER>_BASE_URL` / `<PROVIDER>_MODEL` —
+    and it must say the model has to be multimodal, because report photos and
+    scanned pages go through the vision path (`<PROVIDER>_VISION_MODEL`).
+
+    DashScope stays a fully wired fallback (`config.yaml` and the gates above
+    check it); the README just no longer singles it out by link. The two frozen
+    editions under `archived/` are not checked here.
+    """
+    for name in ("README.md", "README.zh-CN.md"):
         text = (_ROOT / name).read_text(encoding="utf-8")
         assert "openrouter.ai/keys" in text, f"{name}: no OpenRouter key link"
-        assert "dashscope.console.aliyun.com/apiKey" in text, (
-            f"{name}: no DashScope key link — the fallback path is a dead end"
+        assert "platform.openai.com/api-keys" in text, f"{name}: no OpenAI key link"
+        for var in ("<PROVIDER>_BASE_URL", "<PROVIDER>_MODEL", "<PROVIDER>_VISION_MODEL"):
+            assert var in text, f"{name}: does not name {var}"
+        assert "OPENAI_API_KEY" in text and "OPENROUTER_API_KEY" in text, (
+            f"{name}: does not name both OpenAI-compatible key variables"
         )
 
 

--- a/mirobody/test_readme_examples.py
+++ b/mirobody/test_readme_examples.py
@@ -1,6 +1,6 @@
-"""Run the resolver examples the four READMEs print, and check their answers.
+"""Run the resolver examples the two live READMEs print, and check their answers.
 
-The READMEs quote eight `resolve(...)` / `resolve_reading(...)` results with the
+Both READMEs quote eight `resolve(...)` / `resolve_reading(...)` results with the
 LOINC code written in the trailing comment. Nothing checked them. Every other
 number in those files is guarded (`test_readme_numbers.py`), so the examples —
 the part a reader actually copies — were the one unguarded claim, and this repo's
@@ -27,7 +27,7 @@ import re
 import pytest
 
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-_READMES = ["README.md", "README.zh-CN.md", "README.zh-TW.md", "README.ja.md"]
+_READMES = ["README.md", "README.zh-CN.md"]  # the live editions; see archived/README.md
 
 # `resolve("x").loinc   # '718-7'  comment` / `resolve("血脂").resolved  # False`
 #
@@ -75,7 +75,7 @@ def test_readme_resolver_examples_produce_what_they_claim(name):
         )
 
 
-def test_all_four_readmes_run_the_same_calls():
+def test_both_readmes_run_the_same_calls():
     """Translations may reword the comment; they must not diverge on the call."""
     baseline = [expr for expr, _ in _examples("README.md")]
     for name in _READMES[1:]:

--- a/mirobody/test_readme_l10n.py
+++ b/mirobody/test_readme_l10n.py
@@ -1,11 +1,14 @@
-"""The Traditional Chinese README must be Traditional, and every language must
-show the same demo.
+"""Every live README edition must show the same demo, in its own language
+where a localized asset exists, and name only modules that import.
 
-The other README gates (links, numbers) are script-blind and single-language:
-neither notices a Simplified character in the zh-TW narrative, nor a
+The other README gates (links, numbers) are single-language: neither notices a
 translation whose demo section quietly fell a version behind the English
-walkthrough while an already-produced localized GIF sits unreferenced. Both
-failures are silent; both checks are cheap.
+walkthrough while an already-produced localized GIF sits unreferenced. The
+failure is silent; the check is cheap.
+
+Until 1.4.1 this file also checked that README.zh-TW.md contained no Simplified
+characters. That edition is frozen under `archived/` and no longer gated, so the
+check went with it; `archived/README.md` says what brings it back.
 """
 
 from __future__ import annotations
@@ -19,8 +22,6 @@ _ROOT = pathlib.Path(__file__).resolve().parent.parent
 _READMES = {
     "README.md": None,
     "README.zh-CN.md": "zh-CN",
-    "README.zh-TW.md": "zh-TW",
-    "README.ja.md": "ja",
 }
 
 pytestmark = pytest.mark.skipif(
@@ -29,80 +30,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 # ---------------------------------------------------------------------------
-# 1. No simplified characters in the zh-TW README.
-# ---------------------------------------------------------------------------
-
-# Simplified-only characters whose traditional form differs. Curated, not
-# exhaustive (no opencc dependency): every entry is unambiguous — a character
-# that standard Traditional Chinese text has no reason to contain. Characters
-# valid in BOTH scripts (你, 作, 依, 份, 中…) are deliberately absent.
-# Hand-typed, and `test_the_simplified_list_is_actually_simplified` keeps it
-# honest — `骨` used to be in here, swept in beside 驱驶 while someone typed the
-# 马 radical group, and it is the SAME character in Traditional (骨骼, 骨質).
-# The false positive only surfaced when a README first mentioned 骨量.
-_SIMPLIFIED_ONLY = set(
-    "标图谱个总览词数据记录变设红蓝绿级别题细谁说话语请谢电见觉观频账历"
-    "经过还进运银钱铁钟们时间东车书学习门问闻队阶阴阳阵际陆隐离难验预顾"
-    "风飞饭馆马驱驶简体汉无张归当岁币师应库废开异弃发汇圆单双报划义乐"
-    "买卖万与专业丛两严亲亿从众优传伤础纸纯线组织终结给绝统继绩续维绿网"
-    "罗节芦苏药虑虽装见规视览觉计订认讨让训议讯记讲许论设访证评识诊译试"
-)
-
-# Simplified strings the zh-TW README carries ON PURPOSE, verbatim:
-#   - the language switcher's own name for the zh-CN edition;
-#   - the multilingual resolve demo, whose whole point is that a
-#     Simplified-Chinese term lands on the same LOINC code;
-#   - prose that names the Simplified script itself.
-# `中性粒细胞` joins `血红蛋白` for the same reason: the code block demonstrates
-# that a Simplified input resolves, and rewriting the demo into Traditional
-# would delete the thing being shown. The four READMEs run identical calls
-# by design — `test_readme_examples` pins that — so the input stays Hans in
-# all of them and only the comment beside it is translated.
-_DELIBERATE_SIMPLIFIED = (
-    "简体中文", "血红蛋白", "中性粒细胞", "简体", "简→繁", "繁→简",
-)
-
-
-def test_the_simplified_list_is_actually_simplified():
-    """Every char in `_SIMPLIFIED_ONLY` must be the Hans side of a real fold
-    pair, checked against the DERIVED table in `mirobody/zh_fold.py`.
-
-    The list is typed by hand and the gate that uses it fails a README, so a
-    character that is shared between the scripts blocks correct Traditional
-    prose until someone argues with the test. One did: `骨`.
-    """
-    from mirobody.zh_fold import _TABLE
-
-    hans = {chr(v) for v in _TABLE.values()}
-    shared = sorted(c for c in _SIMPLIFIED_ONLY if c not in hans)
-    assert not shared, (
-        f"{''.join(shared)!r} in _SIMPLIFIED_ONLY, but nothing folds TO them — "
-        "they are the same character in both scripts, so flagging them rejects "
-        "correct zh-TW text"
-    )
-
-
-def test_zh_tw_readme_contains_no_stray_simplified_characters():
-    text = (_ROOT / "README.zh-TW.md").read_text(encoding="utf-8")
-    for allowed in _DELIBERATE_SIMPLIFIED:
-        text = text.replace(allowed, "")
-
-    offenders: list[str] = []
-    for lineno, line in enumerate(text.splitlines(), 1):
-        hits = sorted({ch for ch in line if ch in _SIMPLIFIED_ONLY})
-        if hits:
-            offenders.append(f"line {lineno}: {''.join(hits)!r} in {line.strip()[:60]!r}")
-
-    assert not offenders, (
-        "Simplified characters in README.zh-TW.md (outside the deliberate "
-        "demo terms):\n" + "\n".join(offenders)
-        + "\nIf one is intentional, add the full phrase to "
-        "_DELIBERATE_SIMPLIFIED with a reason."
-    )
-
-
-# ---------------------------------------------------------------------------
-# 2. Every language shows the same demo, in its own language where possible.
+# 1. Every language shows the same demo, in its own language where possible.
 # ---------------------------------------------------------------------------
 
 _IMG = re.compile(r'(?:src="|\]\()docs/images/([^")\s]+)')
@@ -152,7 +80,7 @@ def test_translations_use_localized_assets_where_they_exist(name, lang):
 
 
 # ---------------------------------------------------------------------------
-# 3. Every language names the same modules, and every module it names exists.
+# 2. Every language names the same modules, and every module it names exists.
 # ---------------------------------------------------------------------------
 
 _DOTTED = re.compile(r"`(mirobody(?:\.[a-z_][a-z0-9_]*)+)`")

--- a/mirobody/test_readme_links.py
+++ b/mirobody/test_readme_links.py
@@ -1,6 +1,6 @@
 """Every relative link in every README points at something that exists.
 
-The four READMEs carry ~50 relative targets each — module paths, docs, images,
+The two live READMEs carry ~50 relative targets each — module paths, docs, images,
 each other. CONTRIBUTING says "if you rename a module, grep the `.md` files",
 which is a rule that depends on someone remembering. This is the same rule,
 enforced.
@@ -17,7 +17,10 @@ import re
 import pytest
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
-_READMES = ["README.md", "README.zh-CN.md", "README.zh-TW.md", "README.ja.md"]
+# The two LIVE editions. 繁體中文 and 日本語 are frozen at 1.4.0 under `archived/`
+# (each drew under 9 unique visitors in the 14 days before the freeze, against
+# 263 for zh-CN) and are not gated; `archived/README.md` says how to revive one.
+_READMES = ["README.md", "README.zh-CN.md"]
 
 pytestmark = pytest.mark.skipif(
     not (_ROOT / "README.md").is_file(),
@@ -45,8 +48,10 @@ def test_every_relative_link_resolves(name):
     assert not missing, f"{name} links to nonexistent paths: {missing}"
 
 
-def test_all_four_languages_exist_and_cross_link():
-    """The switcher must offer four working links from every language.
+def test_both_live_editions_exist_and_cross_link():
+    """The switcher must offer a working link to the other live edition, and
+    the frozen editions must still be on disk under `archived/` (unadvertised —
+    the archive is deliberately not linked from the live pages).
 
     A translated README that links a sibling which was never written is worse
     than not offering the switcher: it looks finished and 404s.
@@ -61,6 +66,8 @@ def test_all_four_languages_exist_and_cross_link():
             assert f"]({other})" in text, f"{name} does not link to {other}"
         # and the current language is plain text, not a link to itself
         assert f"]({name})" not in text, f"{name} links to itself in the switcher"
+    for frozen in ("README.zh-TW.md", "README.ja.md"):
+        assert (_ROOT / "archived" / frozen).is_file(), f"archived/{frozen} is missing"
 
 
 @pytest.mark.parametrize("name", _READMES)
@@ -91,10 +98,12 @@ def test_a_translated_readme_uses_its_own_diagrams(name):
     # language that has not been recorded yet still passes on the English file.
     # Adding `docs/images/<stem>.<lang>.gif` is therefore what makes this test
     # start demanding it.
-    # All FIVE scenes: a scene absent from a translation is a silently shorter
-    # narrative — the reader of that language never learns the capability
-    # exists.
-    for stem in ("care-circle-demo", "upload-demo", "ask-circle-demo", "ask-own-demo"):
+    # The README shows three of the four walkthrough scenes since 1.4.1 — the
+    # care circle you arrive in, ① Collect + ② Translate on an upload, ③ Answer
+    # on the shared record — and links docs/walkthrough.md for the fourth. A
+    # scene absent from a translation is still a silently shorter narrative, so
+    # both live editions must carry the same three.
+    for stem in ("care-circle-demo", "upload-demo", "ask-circle-demo"):
         localized = f"docs/images/{stem}{lang}.gif"
         if lang and (_ROOT / localized).is_file():
             assert localized in text, (
@@ -105,10 +114,8 @@ def test_a_translated_readme_uses_its_own_diagrams(name):
             assert f"docs/images/{stem}.gif" in text, f"{name} should embed {stem}.gif"
 
 
-# The docs site carries en and zh only. A Japanese reader therefore belongs on
-# /en/ — /zh/ would be worse than English, not better.
-_DOCS_LOCALE = {"README.md": "en", "README.zh-CN.md": "zh",
-                "README.zh-TW.md": "zh", "README.ja.md": "en"}
+# The docs site carries en and zh only, matching the two live editions.
+_DOCS_LOCALE = {"README.md": "en", "README.zh-CN.md": "zh"}
 _DOCS_LINK = re.compile(r"https://docs\.mirobody\.ai/([a-z-]+)/")
 
 

--- a/mirobody/test_readme_numbers.py
+++ b/mirobody/test_readme_numbers.py
@@ -2,14 +2,14 @@
 
 ``test_readme_links.py`` guards the links and the per-language diagrams; this
 file gates the figures — alias counts, graph sizes, the resolver score. They
-are quoted in four files and derived in none, so nothing short of a gate keeps
+are quoted in two files and derived in none, so nothing short of a gate keeps
 them honest.
 
 The check is presence of today's value, not parsing of the prose: for each
 claim the README must contain the number the code currently produces, written
 the way the READMEs write numbers (thousands separated). A bundle rebuild that
 moves an alias count therefore turns these red, which is the point — those
-counts are quoted in four files and derived in none.
+counts are quoted in two files and derived in none.
 
 Two claims cannot be checked by presence alone and get a regex instead: the
 pulse-indicator count, because a bare ``300`` also matches inside ``4,300+``;
@@ -38,7 +38,7 @@ import pytest
 from ruamel.yaml import YAML
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
-_READMES = ["README.md", "README.zh-CN.md", "README.zh-TW.md", "README.ja.md"]
+_READMES = ["README.md", "README.zh-CN.md"]  # the live editions; see archived/README.md
 
 
 def _text(name: str) -> str:


### PR DESCRIPTION
README-only change, rebased on current `main` (c44eba2). No code moves; the five test files touched are the README gates, which had four editions hardcoded.

## What changes

- **Stages renamed C·T·A: Collect · Translate (standardize) · Answer (agent).** Stage names only — `indicator/`, `standardize/`, the docs slug and CHANGELOG keep the technical term. Code comments still say ② Standardize / ③ Answers; that prose-only sweep is a separate change.
- **Two live editions: English and 中文.** `README.zh-TW.md` and `README.ja.md` are frozen at 1.4.0 under `archived/` with a short notice. Evidence: 14 days of traffic (08-23 → 09-05) had zh-CN at 263 unique visitors, ja and zh-TW each under 9. Engine support for Traditional Chinese and Japanese is unchanged and still gated by `test_engine_coverage.py`.
- **510 → 237 lines.** The vocabulary deep-dive, the directory map and the four-scene walkthrough move to `docs/standardization.md`, `docs/repository-layout.md`, `docs/walkthrough.md`. Every gated figure stays in a seven-row "By the numbers" table; the eight `resolve()` examples are verbatim.
- **Model wording.** Recommends any OpenAI-compatible endpoint (OpenAI / OpenRouter / `<PROVIDER>_BASE_URL` + `<PROVIDER>_MODEL`) and states the model must be multimodal (`<PROVIDER>_VISION_MODEL`). DashScope remains wired in `config.yaml`, no longer linked from the README; no regional wording anywhere.
- **`.github/ISSUE_TEMPLATE/wrong-term.yml`** — the "resolver got a term wrong" form the Contributing section links.

## Gates

| gate | before | after |
| --- | --- | --- |
| `test_readme_links/numbers/examples/l10n` | 4 editions | 2 live editions + both link `archived/` |
| `test_readme_l10n` zh-TW script check | present | retired with the file |
| `test_one_key_defaults::test_every_readme_hands_out_both_key_links` | requires DashScope link ×4 | `…hands_out_the_openai_compatible_path`: OpenAI + OpenRouter key pages, three `<PROVIDER>_*` names, ×2 |

`pytest -q mirobody` → 290 passed on top of c44eba2; `uvx ruff check` clean on the touched tests.

## Follow-ups (not in this PR)

- `fix/indicators-and-circle-list` deletes the pgsql provider; when it lands, drop "+ a SQL source" from the ① Collect row in both READMEs. It also carries the old `test_every_readme_hands_out_both_key_links`, which this PR replaces — rebase that branch after this merges.
- Comment/docstring sweep to the new stage names (19 files, prose only).
- docs.mirobody.ai still says "C · S · A" once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
