### PR TITLE
comments: the stage names follow the README — ② Translate, ③ Answer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ machine-checked (`lint-imports`, contracts in `pyproject.toml`):
 
 | Layer | Where | Installs with | May import |
 |---|---|---|---|
-| ② Standardize + the kernel (the library) | vocabulary: `engine.py`, `lexical.py`, `units/`, `value_scale.py`, `zh_fold.py`, `_bundle.py`, `_strtab.py`; semantics: **`kernel/`** (`metrics`, `series`, `quality`, `overlay`, `meds`, `query`, `tools`, `ops`, `connect`, `sink`, `events`, `evidence`, `memory`, `vendors/`); toolbox: `testing/` | `pip install mirobody` (numpy only) | each other, nothing else |
+| ② Translate + the kernel (the library) | vocabulary: `engine.py`, `lexical.py`, `units/`, `value_scale.py`, `zh_fold.py`, `_bundle.py`, `_strtab.py`; semantics: **`kernel/`** (`metrics`, `series`, `quality`, `overlay`, `meds`, `query`, `tools`, `ops`, `connect`, `sink`, `events`, `evidence`, `memory`, `vendors/`); toolbox: `testing/` | `pip install mirobody` (numpy only) | each other, nothing else |
 | ① Collect + storage + MCP | `mirobody/documents/`, `pulse/`, `indicator/`, `utils/`, `user/`, `task/`, `mcp/` | `[parse]` / `[app]` | no `langchain*`, `langgraph`, `deepagents` |
-| ③ Answers | `mirobody/agent/` (one agent: `MirobodyAgent`, on `deepagents`), `server/` | `[agent]` (the harness as a library) / `[app]` | anything |
+| ③ Answer | `mirobody/agent/` (one agent: `MirobodyAgent`, on `deepagents`), `server/` | `[agent]` (the harness as a library) / `[app]` | anything |
 
 There is one agent, and it is not switched at request time. `BaseAgent`,
 the `agent/base` package and the ChatGPT Apps widgets under `agent/resources`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,7 +50,7 @@ five:
 | Suite | Covers | Notes |
 | --- | --- | --- |
 | `mirobody/test_engine_coverage.py` | **the published accuracy number** | the case table: the panels an ordinary checkup includes, in en / 简体中文 / 繁體中文 / 日本語, plus device vocabulary, report shapes (`名称(缩写)`, `Name-ABBREV`, snake_case, full-width), unit-dependent codes and non-numeric readings. Run with `-s` to print the score; `COVERAGE_FLOOR = 1.0` |
-| `mirobody/test_engine.py` | golden LOINC codes for ② Standardize | pins the whole chain: alias index → commonness prior → axis table |
+| `mirobody/test_engine.py` | golden LOINC codes for ② Translate | pins the whole chain: alias index → commonness prior → axis table |
 | `mirobody/test_readme_numbers.py` | every figure the four READMEs publish | each one re-derived from the artifact or code that defines it, so a number cannot drift silently |
 | `mirobody/test_readme_links.py` | every link and demo asset in the four READMEs | a dead relative link is a broken promise on the front page; localized GIFs must be referenced by their own translations |
 | `mirobody/test_readme_l10n.py` | the translations themselves | script hygiene (no Simplified characters in 繁體中文), and every language shows the same demo |

--- a/examples/01_resolve_offline.py
+++ b/examples/01_resolve_offline.py
@@ -3,7 +3,7 @@
     pip install mirobody
     python examples/01_resolve_offline.py
 
-This is the whole of ② Standardize in library form. Everything below runs against the
+This is the whole of ② Translate in library form. Everything below runs against the
 data bundles shipped inside the package: no PostgreSQL, no Redis, no server, no
 API key, and no outbound connection. Unplug the network and it still works.
 

--- a/examples/03_parse_a_lab_report.py
+++ b/examples/03_parse_a_lab_report.py
@@ -4,7 +4,7 @@
     export OPENAI_API_KEY=...          # or ANTHROPIC_API_KEY / GOOGLE_API_KEY
     python examples/03_parse_a_lab_report.py path/to/report.pdf
 
-This is ① Collect + ② Standardize in a single function. `parse_file()` sends the
+This is ① Collect + ② Translate in a single function. `parse_file()` sends the
 document to one model to extract name/value/unit, then resolves every extracted
 name **offline** against the shipped bundles. No database, no `mirobody serve`,
 no agent framework.

--- a/examples/05_agent_server_preflight.py
+++ b/examples/05_agent_server_preflight.py
@@ -3,7 +3,7 @@
     pip install 'mirobody[app]'
     python examples/05_agent_server_preflight.py
 
-Examples 01–04 need nothing but the package. This one covers ③ Answers, which is
+Examples 01–04 need nothing but the package. This one covers ③ Answer, which is
 a different proposition: the chat server, the MCP endpoint over HTTP, and the
 agents need PostgreSQL, Redis, a model key and a JWT secret.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,10 +6,10 @@ missing step.
 
 | | Example | Needs | Shows |
 |---|---|---|---|
-| 01 | [`01_resolve_offline.py`](01_resolve_offline.py) | `pip install mirobody` | ② Standardize: name → LOINC, any language, fully offline |
+| 01 | [`01_resolve_offline.py`](01_resolve_offline.py) | `pip install mirobody` | ② Translate: name → LOINC, any language, fully offline |
 | 02 | [`02_standardize_a_reading.py`](02_standardize_a_reading.py) | `pip install mirobody` | ① Collect: unit conversion + the indicator catalogue |
 | 03 | [`03_parse_a_lab_report.py`](03_parse_a_lab_report.py) | + one model key | a document → standardized readings in one call |
-| 04 | [`04_mcp_tool_surface.py`](04_mcp_tool_surface.py) | `pip install 'mirobody[parse]'` | ③ Answers: exactly what an external MCP client receives |
+| 04 | [`04_mcp_tool_surface.py`](04_mcp_tool_surface.py) | `pip install 'mirobody[parse]'` | ③ Answer: exactly what an external MCP client receives |
 | 05 | [`05_agent_server_preflight.py`](05_agent_server_preflight.py) | `pip install 'mirobody[app]'` | whether this machine can run the full server, and what is missing |
 | 06 | [`06_care_circle_rules.py`](06_care_circle_rules.py) | `pip install mirobody` | who may read whose record — the rule behind the README's demo |
 | 07 | [`07_claude_agent_sdk.py`](07_claude_agent_sdk.py) | a running mirobody + `pip install claude-agent-sdk` + a model key | another agent runtime answering from this data over `/mcp` — no mirobody import at all |

--- a/mirobody/__init__.py
+++ b/mirobody/__init__.py
@@ -2,7 +2,7 @@
 
 The public surface of a `pip install mirobody`, in three imports::
 
-    from mirobody import resolve, resolve_reading   # ② Standardize, offline
+    from mirobody import resolve, resolve_reading   # ② Translate, offline
     from mirobody.units import normalize_unit, unit_family
     from mirobody.lexical import normalize, word_tokens
 

--- a/mirobody/_bundle.py
+++ b/mirobody/_bundle.py
@@ -14,7 +14,7 @@ resolver needs::
 
 **Why this module is at the package root rather than inside
 ``indicator/fhir/embeddings/``, where it used to live.** ``engine.py`` — the
-front door of ② Standardize, and the one thing a `pip install mirobody`
+front door of ② Translate, and the one thing a `pip install mirobody`
 actually runs — read its data through the bundle-BUILD package, and reached
 into it for a private symbol (``alias._normalize``) besides. So the runtime
 depended on the build tooling, which meant the build tooling could never be

--- a/mirobody/agent/__init__.py
+++ b/mirobody/agent/__init__.py
@@ -1,4 +1,4 @@
-"""③ Answers: the agent, its tools, and the chat surface.
+"""③ Answer: the agent, its tools, and the chat surface.
 
     agent.py        `MirobodyAgent` — one turn, end to end (LangChain +
                     deepagents)

--- a/mirobody/agent/tools/README.md
+++ b/mirobody/agent/tools/README.md
@@ -6,7 +6,7 @@ Mirobody follows a **"Tools First"** philosophy. You write standard Python code,
 
 Tool directories are configured by `MCP_TOOL_DIRS` in `config.{env}.yaml`. The defaults:
 
-1. **Built-in tools**: `mirobody/agent/tools/` (this directory) — the whole shipped tool surface: terminology (② Standardize), health records, genetics.
+1. **Built-in tools**: `mirobody/agent/tools/` (this directory) — the whole shipped tool surface: terminology (② Translate), health records, genetics.
 
 **Place your own tools in your own directory and add it to `MCP_TOOL_DIRS`** — the list is ordinary config, so a deployment can extend it without touching the package:
 

--- a/mirobody/agent/tools/__init__.py
+++ b/mirobody/agent/tools/__init__.py
@@ -52,7 +52,7 @@ DIRECTORY STRUCTURE
 
 tools/
 ├── __init__.py                      # This documentation
-├── terminology_service.py           # ② Standardize over MCP: resolve_indicator, normalize_unit
+├── terminology_service.py           # ② Translate over MCP: resolve_indicator, normalize_unit
 │                                    #   (offline, no user data — works anonymously)
 ├── health_indicators_service.py     # query_health_indicators — readings: catalogue,
 │                                    #   raw rows, buckets, stats, latest (8 parameters)

--- a/mirobody/agent/tools/terminology_service.py
+++ b/mirobody/agent/tools/terminology_service.py
@@ -1,4 +1,4 @@
-"""Terminology tools — ② Standardize, exposed over MCP.
+"""Terminology tools — ② Translate, exposed over MCP.
 
 This is the engine's differentiator on the tool surface. Every other health MCP
 server hands the model *vendor-shaped* data and leaves naming to chance:

--- a/mirobody/cli.py
+++ b/mirobody/cli.py
@@ -35,7 +35,7 @@ def _require_extra(command: str, extra: str, marker: str, what: str) -> None:
     opaque ``ModuleNotFoundError``. Checking one marker dependency up front and
     naming the pip command is the entire fix.
 
-    ``pip install mirobody`` is ② Standardize — ``resolve``, units, lexical,
+    ``pip install mirobody`` is ② Translate — ``resolve``, units, lexical,
     numpy and nothing else. That is deliberate: it is the surface other
     software depends ON, and it used to drag 93 packages and 245 MB behind it.
     """

--- a/mirobody/engine.py
+++ b/mirobody/engine.py
@@ -11,7 +11,7 @@ credentials at all (pure offline lookup against the shipped data bundles);
     await parse_file("labs.pdf")       # -> readings + resolutions, one LLM call
 
 This is the deliberate small door into the first two engine stages (① Collect,
-② Standardize) — the same machinery the full platform uses, minus its persistence:
+② Translate) — the same machinery the full platform uses, minus its persistence:
 
 * **Lexical resolution** rides the shipped LOINC bundle: the 921k-entry
   multilingual alias index (``loinc_alias_index.npz``), the 677k-name corpus

--- a/mirobody/units/README.md
+++ b/mirobody/units/README.md
@@ -1,6 +1,6 @@
 # Units
 
-UCUM units, unit families and conversions — the half of ② Standardize that
+UCUM units, unit families and conversions — the half of ② Translate that
 answers "is this number comparable to that one". Pure Python, no data bundle,
 no network: `pip install mirobody` gets all of it.
 

--- a/mirobody/units/convert.py
+++ b/mirobody/units/convert.py
@@ -41,7 +41,7 @@ which is a different job on the other side of the pipeline: it takes a
 ``StandardIndicator`` enum member and converts to *that device indicator's*
 declared canonical unit (① Collect, one target per indicator). This module takes
 two arbitrary UCUM strings and asks whether they are interconvertible at all
-(② Standardize, no target). Use that one to canonicalize a device sample; use
+(② Translate, no target). Use that one to canonicalize a device sample; use
 this one to compare two readings.
 """
 

--- a/mirobody/utils/i18n.py
+++ b/mirobody/utils/i18n.py
@@ -25,7 +25,7 @@ class I18n:
         "zh-hans": "zh",
         "zh_hans": "zh",
         # Traditional variants map to the Simplified bundle: we ship a
-        # README.zh-TW.md, and Chinese text is closer than the English default.
+        # archived/README.zh-TW.md, and Chinese text is closer than the English default.
         "zh-tw": "zh",
         "zh_tw": "zh",
         "zh-hant": "zh",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 # about it. The Docker application is a PRODUCT and wants everything in the
 # box. Until 1.3.0 the pyproject described only the second: base carried the
 # whole ① Collect extraction stack and three LLM SDKs, so a consumer who wanted
-# ② Standardize — offline name → LOINC, UCUM units — installed 93 packages and
+# ② Translate — offline name → LOINC, UCUM units — installed 93 packages and
 # 245 MB, of which mirobody itself was 29 MB.
 #
 # That was not merely wasteful. `mcp>=2.0.0` in base made the package
@@ -59,7 +59,7 @@ classifiers = [
 # is numpy and nothing else (measured — `import mirobody.engine` pulls zero
 # third-party packages; numpy is imported inside `OfflineResolver.__init__`).
 dependencies = [
-    # ② Standardize. The offline resolver rebuilds the 921k-alias index from
+    # ② Translate. The offline resolver rebuilds the 921k-alias index from
     # .npz on every construction, and `mirobody/units/` reads none of it — but
     # 20 modules under indicator/ import numpy at module level. It went
     # undeclared for a long time and worked only because pandas (since
@@ -320,7 +320,7 @@ include = ["mirobody", "mirobody.*"]
     "**/*.so",
     # ── engine data bundles (Git LFS) ────────────────────────────────────────
     # These are not optional extras: `mirobody.engine.resolve` — the front door
-    # of ② Standardize, and the one line the README leads with — reads
+    # of ② Translate, and the one line the README leads with — reads
     # res/fhir_loinc_bundle.tar.gz, res/fhir_meta.csv.gz and res/aliases_src/*.tsv
     # at import time. Until 1.0.62 only *.bin was listed here, so every published
     # wheel shipped an engine that could not resolve anything. Keep .gz/.npy/.tsv
@@ -384,9 +384,9 @@ markers = [
 # ── Architectural boundary, machine-enforced (run: lint-imports) ─────────────
 #
 # The engine follows the langchain / langchain-core layering: the DATA ENGINE
-# (① Collect: pulse · ② Standardize: indicator, plus the shared utils/user/mcp/task
+# (① Collect: pulse · ② Translate: indicator, plus the shared utils/user/mcp/task
 # infra) must stay importable without any agent framework, while the AGENT
-# LAYER (③ Answers: agent, server) is the only place LangChain and friends
+# LAYER (③ Answer: agent, server) is the only place LangChain and friends
 # may appear. These contracts turn that rule from a convention into a CI check.
 # import-linter parses function-local imports too, so lazy imports can't sneak
 # a violation past it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # mounts the checkout and pip-installs from it, so PyPI is never a deployment
 # path and `[app]` never asks anyone to choose a backend.
 #
-# A bare `pip install mirobody` is the LIBRARY: ② Standardize (resolve, units,
+# A bare `pip install mirobody` is the LIBRARY: ② Translate (resolve, units,
 # lexical) on numpy alone. `pip install 'mirobody[parse]'` adds ① Collect's
 # single-file surface. See pyproject.toml for why there are only those two.
 -e .[app]


### PR DESCRIPTION
Prose-only follow-up to #67: comments, docstrings, pyproject notes and the small package READMEs now use the README's stage names — **② Translate**, **③ Answer** (19 files). No identifier, module, package, docs slug or CHANGELOG entry changes; `archived/` keeps the 1.4.0 names on purpose.

Verified: `uvx ruff check mirobody examples` · `pytest -q mirobody` · `lint-imports` (4 contracts kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
